### PR TITLE
Allow disabling usb.ids (and script) install.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,14 +4,12 @@ SUBDIRS = \
 AM_LDFLAGS = \
 	-Wl,--as-needed
 
-data_DATA = \
-	usb.ids
+data_DATA =
 
 bin_PROGRAMS = \
 	lsusb
 
-sbin_SCRIPTS = \
-	update-usbids.sh
+sbin_SCRIPTS =
 
 bin_SCRIPTS = \
 	usb-devices \
@@ -33,7 +31,6 @@ lsusb_LDADD = \
 	$(LIBUSB_LIBS)
 
 if HAVE_ZLIB
-data_DATA += usb.ids.gz
 lsusb_CPPFLAGS += -DHAVE_LIBZ
 lsusb_LDADD += -lz
 endif
@@ -51,12 +48,22 @@ EXTRA_DIST = \
 	lsusb.py \
 	usbutils.pc.in
 
+if INSTALL_USBIDS
+data_DATA += usb.ids
+
+if HAVE_ZLIB
+data_DATA += usb.ids.gz
+endif
+
+sbin_SCRIPTS += update-usbids.sh
+
 usb.ids.gz: $(srcdir)/usb.ids
 	gzip -c -9 $< > $@
 
 update-usbids.sh: $(srcdir)/update-usbids.sh.in
 	sed 's|@usbids@|$(datadir)/usb.ids|g' $< >$@
 	chmod 755 $@
+endif
 
 lsusb.8: $(srcdir)/lsusb.8.in
 	sed 's|VERSION|$(VERSION)|g;s|@usbids@|$(datadir)/usb.ids|g' $< >$@

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,10 @@ AS_IF([test "x$enable_zlib" != "xno"],
 	[AC_CHECK_LIB(z, inflateEnd, HAVE_ZLIB=yes)])
 AM_CONDITIONAL(HAVE_ZLIB, [test "$HAVE_ZLIB" = "yes"])
 
+AC_ARG_ENABLE(usbids,
+	AS_HELP_STRING(--disable-usbids, [disable installing usb.ids @<:@default=install@:>@]))
+AM_CONDITIONAL([INSTALL_USBIDS], [test "x$enable_usbids" != "xno"])
+
 PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.0)
 
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Also avoid installing update-usbids.sh script if we're not going to
install usb.ids. This is useful for Gentoo since we now have a
separate package for usb.ids, which can be updated independently, and
that can be updated without this script.
