### PR TITLE
Minor issue: lsusb -V should not take a argument

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -3930,7 +3930,7 @@ int main(int argc, char *argv[])
 	char *cp;
 	int status;
 
-	while ((c = getopt_long(argc, argv, "D:vxtP:p:s:d:V:h",
+	while ((c = getopt_long(argc, argv, "D:vxtP:p:s:d:Vh",
 			long_options, NULL)) != EOF) {
 		switch (c) {
 		case 'V':


### PR DESCRIPTION
Hi Greg,

   I just found the latest commit won't show version information when invoked by 'lsusb -V'. This
patch revises the optstring for getopt to correctly interpret option -V. Please review it.

Signed-off-by: Roger Tseng rogerable@realtek.com
