### PR TITLE
Support non-ASCII string descriptors in lsusb

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
 
 AC_CHECK_HEADERS([byteswap.h])
+AC_CHECK_FUNCS([nl_langinfo iconv])
 
 AC_ARG_ENABLE(zlib,
 	AS_HELP_STRING(--disable-zlib,disable support for zlib))

--- a/usbmisc.h
+++ b/usbmisc.h
@@ -27,5 +27,7 @@
 
 extern libusb_device *get_usb_device(libusb_context *ctx, const char *path);
 
+extern char *get_dev_string(libusb_device_handle *dev, u_int8_t id);
+
 /* ---------------------------------------------------------------------- */
 #endif /* _USBMISC_H */


### PR DESCRIPTION
This replaces the `get_string` function with `get_dev_string`, which
obtains the string descriptor in raw UTF-16 and attempts to iconv
it to the current locale's encoding. If that fails, or if the system
lacks the required functions, it falls back to ASCII.
