### PR TITLE
Fix lsusb -t potentially not listing all devices

### DIFF
--- a/lsusb-t.c
+++ b/lsusb-t.c
@@ -328,7 +328,7 @@ static void add_usb_device(const char *d_name)
 		return;
 	memset(d, 0, sizeof(struct usbdevice));
 	d->busnum = i;
-	while (pn) {
+	while (*pn) {
 		p = pn + 1;
 		i = strtoul(p, &pn, 10);
 		if (p == pn)


### PR DESCRIPTION
There's a bug in the path-parsing code of add_usb_device(). It never checks for
a NULL terminator. This causes some devices to have a bogus
portnum/parent_portnum which in turn makes them not show in the device tree.

Here are two real-world test-cases (yes, the \0 is intentional):
Shows up: `add_usb_device("1-1.5.1.4.1\0\n\241M")`
Disappers: `add_usb_device("1-1.5.1.4.2\0\n0c")`
