### PR TITLE
Ignore invalid string descriptors

### DIFF
--- a/usbmisc.c
+++ b/usbmisc.c
@@ -229,6 +229,9 @@ char *get_dev_string(libusb_device_handle *dev, u_int8_t id)
 	                                   sizeof unicode_buf);
 	if (ret < 2) return strdup("(error)");
 
+	if (unicode_buf[0] < 2 || unicode_buf[1] != LIBUSB_DT_STRING)
+		return strdup("(error)");
+
 	buf = usb_string_to_native(unicode_buf + 2,
 	                           ((unsigned char) unicode_buf[0] - 2) / 2);
 


### PR DESCRIPTION
This Ralink Wi-Fi adapter reports bogus values for some string
descriptors (iSerial and iInterface). As the current
libusb_get_string_descriptor function from 1.0.17 does not validate the
length or type and returns 254 even if the descriptor says 0, explicitly
check the fields before proceeding.

Fixes the following crash:

```
lsusb: gconv.c:74: __gconv: Assertion `outbuf != ((void *)0) && *outbuf != ((void *)0)' failed.
```

libusbx bug: https://github.com/libusbx/libusbx/pull/156

Signed-off-by: Peter Wu lekensteyn@gmail.com
