### PR TITLE
New path for usbhid-dump submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "usbhid-dump"]
 	path = usbhid-dump
-	url = git://digimend.git.sourceforge.net/gitroot/digimend/usbhid-dump.git
+	url = git://git.code.sf.net/p/digimend/usbhid-dump


### PR DESCRIPTION
SourceForge has changed git path, so this PR updates the submodule origin
