### PR TITLE
usb-devices: hexadecimal bInterfaceNumber handling

### DIFF
--- a/usb-devices
+++ b/usb-devices
@@ -77,7 +77,7 @@ print_interface() {
 	fi
 	classname=`class_decode $class`
 	printf "I:  If#=%2i Alt=%2i #EPs=%2i Cls=%s(%s) Sub=%s Prot=%s Driver=%s\n" \
-		${ifnum#0} ${altset#0} ${numeps#0} $class "$classname" $subclass \
+		0x${ifnum#0} ${altset#0} ${numeps#0} $class "$classname" $subclass \
 		$protocol $driver
 
 	for endpoint in $ifpath/ep_??


### PR DESCRIPTION
```
# lsusb -s 1:2
Bus 001 Device 002: ID 0421:0264 Nokia Mobile Phone
# cat /sys/bus/usb/devices/usb1/1-2/1-2:1.10/bInterfaceNumber
0a
# bash -vx usb-devices
[...]
printf 'I:  If#=%2i Alt=%2i #EPs=%2i Cls=%s(%s) Sub=%s Prot=%s Driver=%s\n' 0a 0 00 02 commc 0b 00 '(none)'
bash: printf: 0a: invalid number
[...]
```

see issue #25 
