### PR TITLE
Makefile: install pkgconfig file to arch-dependent location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,7 +48,7 @@ lsusb.8: $(srcdir)/lsusb.8.in
 usb-devices.1: $(srcdir)/usb-devices.1.in
 	sed 's|VERSION|$(VERSION)|g' $< >$@
 
-pkgconfigdir = $(datarootdir)/pkgconfig
+pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = usbutils.pc
 
 usbutils.pc: $(srcdir)/usbutils.pc.in


### PR DESCRIPTION
pkgconfig files should be installed to the arch-dependent library directory, rather than
/usr/share, since they involve arch-dependent files.