### PR TITLE
build: Request at least libusb 1.0.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_SYS_LARGEFILE
 AC_CHECK_HEADERS([byteswap.h])
 AC_CHECK_FUNCS([nl_langinfo iconv])
 
-PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.0)
+PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.9)
 
 PKG_CHECK_MODULES(UDEV, libudev >= 196)
 


### PR DESCRIPTION
lsusb needs at least libusb 1.0.9 as it uses libusb_error_name.
Otherwise the build fails with the following linker error:

lsusb-lsusb.o: In function `do_hub':
.../usbutils/lsusb.c:3314: undefined reference to `libusb_error_name'

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>