### PR TITLE
autogen.sh: checkout usbhid-dump

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -e
 
+if test ! -f usbhid-dump/bootstrap; then
+git submodule update --init --recursive
+fi
+
 cd usbhid-dump
 ./bootstrap
 cd ..


### PR DESCRIPTION
The INSTALL file does not describe how to set up usbhid-dump.

Let's add the git submodule action to autogen.sh.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>