### PR TITLE
add UVC1.5 video control interface descriptors and fix some minor bugs

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -2261,7 +2261,7 @@ static void dump_videocontrol_interface(libusb_device_handle *dev, const unsigne
 		}
 		stds = buf[9+n];
 		printf("        iProcessing         %5u %s\n"
-		       "        bmVideoStandards     0x%2x\n", buf[8+n], term, stds);
+		       "        bmVideoStandards     0x%02x\n", buf[8+n], term, stds);
 		for (i = 0; i < 6; i++)
 			if ((stds >> i) & 1)
 				printf("          %s\n", stdnames[i]);

--- a/lsusb.c
+++ b/lsusb.c
@@ -2433,7 +2433,7 @@ static void dump_videostreaming_interface(const unsigned char *buf)
 			printf("Random pattern of fields 1 and 2\n");
 			break;
 		}
-		printf("        bCopyProtect                  %5u\n", buf[26]);
+		printf("        bCopyProtect                    %5u\n", buf[26]);
 		if (buf[2] == 0x10)
 			printf("        bVariableSize                 %5u\n", buf[27]);
 		dump_junk(buf, "        ", len);
@@ -2537,7 +2537,7 @@ static void dump_videostreaming_interface(const unsigned char *buf)
 			printf("Random pattern of fields 1 and 2\n");
 			break;
 		}
-		printf("        bCopyProtect                  %5u\n", buf[10]);
+		printf("        bCopyProtect                    %5u\n", buf[10]);
 		dump_junk(buf, "        ", 11);
 		break;
 

--- a/lsusb.c
+++ b/lsusb.c
@@ -2116,6 +2116,14 @@ static void dump_videocontrol_interface(libusb_device_handle *dev, const unsigne
 		"Roll (Absolute)", "Roll (Relative)", "Reserved", "Reserved", "Focus, Auto",
 		"Privacy"
 	};
+	static const char * const enctrlnames[] = {
+		"Select Layer", "Profile and Toolset", "Video Resolution", "Minimum Frame Interval",
+		"Slice Mode", "Rate Control Mode", "Average Bit Rate", "CPB Size", "Peak Bit Rate",
+		"Quantization Parameter", "Synchronization and Long-Term Reference Frame",
+		"Long-Term Buffer", "Picture Long-Term Reference", "LTR Validation",
+		"Level IDC", "SEI Message", "QP Range", "Priority ID", "Start or Stop Layer/View",
+		"Error Resiliency"
+	};
 	static const char * const stdnames[] = {
 		"None", "NTSC - 525/60", "PAL - 625/50", "SECAM - 625/50",
 		"NTSC - 625/50", "PAL - 525/60" };
@@ -2261,6 +2269,30 @@ static void dump_videocontrol_interface(libusb_device_handle *dev, const unsigne
 		printf("        iExtension          %5u %s\n",
 		       buf[23+p+n], term);
 		dump_junk(buf, "        ", 24+p+n);
+		break;
+
+	case 0x07: /* ENCODING UNIT */
+		printf("(ENCODING UNIT)\n");
+		term = get_dev_string(dev, buf[5]);
+		if (buf[0] < 13)
+			printf("      Warning: Descriptor too short\n");
+		printf("        bUnitID             %5u\n"
+		       "        bSourceID           %5u\n"
+		       "        iEncoding           %5u %s\n"
+		       "        bControlSize        %5u\n",
+		       buf[3], buf[4], buf[5], term, buf[6]);
+		for (i = 0; i < 3; i++)
+			ctrls = (ctrls << 8) | buf[9-i];
+		printf("        bmControls              0x%08x\n", ctrls);
+		for (i = 0; i < 20;  i++)
+			if ((ctrls >> i) & 1)
+				printf("          %s\n", enctrlnames[i]);
+		for (i = 0; i< 3; i++)
+			ctrls = (ctrls << 8) | buf[12-i];
+		printf("        bmControlsRuntime       0x%08x\n", ctrls);
+		for (i = 0; i < 20; i++)
+			if ((ctrls >> i) & 1)
+				printf("          %s\n", enctrlnames[i]);
 		break;
 
 	default:


### PR DESCRIPTION
Hi, Greg

To display with USB Video Class 1.5 video, add UVC1.5 Video control interface descriptors and do some fix minor bus(line alignment and hexadecimal display value).

Please review it, if you have time :-)

Thanks, jaejoong