### PR TITLE
add support for usb video with streaming interfaces on endpoints

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -766,6 +766,18 @@ static void dump_endpoint(libusb_device_handle *dev, const struct libusb_interfa
 				case LIBUSB_CLASS_MASS_STORAGE:
 					dump_pipe_desc(buf);
 					break;
+				case USB_CLASS_VIDEO:
+					switch (interface->bInterfaceSubClass) {
+					case 1:
+						dump_videocontrol_interface(dev, buf, interface->bInterfaceProtocol);
+						break;
+					case 2:
+						dump_videostreaming_interface(buf);
+						break;
+					default:
+						goto dump;
+					}
+				        break;
 				default:
 					printf("        INTERFACE CLASS: ");
 					dump_bytes(buf, buf[0]);
@@ -802,7 +814,7 @@ static void dump_endpoint(libusb_device_handle *dev, const struct libusb_interfa
 				break;
 			default:
 				/* often a misplaced class descriptor */
-				printf("        ** UNRECOGNIZED: ");
+dump:				printf("        ** UNRECOGNIZED: ");
 				dump_bytes(buf, buf[0]);
 				break;
 			}


### PR DESCRIPTION
Several camera manufacturers seem to report video streaming interfaces this way.

Before:
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.01
  bDeviceClass          239 Miscellaneous Device
  bDeviceSubClass         2 ?
  bDeviceProtocol         1 Interface Association
  bMaxPacketSize0        64
  idVendor           0x05a3 ARC International
  idProduct          0x8830 
  bcdDevice            1.00
  iManufacturer           2 
  iProduct                1 
  iSerial                 3 
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength          897
    bNumInterfaces          2
    bConfigurationValue     1
    iConfiguration          0 
    bmAttributes         0x80
      (Bus Powered)
    MaxPower              256mA
   <.... VideoControl Interface elided ...>
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        1
      bAlternateSetting       0
      bNumEndpoints           1
      bInterfaceClass        14 Video
      bInterfaceSubClass      2 Video Streaming
      bInterfaceProtocol      0 
      iInterface              0 
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x82  EP 2 IN
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               1
        INTERFACE CLASS:  0f 24 01 02 df 02 82 00 05 02 01 01 01 00 00
        INTERFACE CLASS:  0b 24 06 01 0a 00 01 00 00 00 00
        INTERFACE CLASS:  1e 24 07 01 00 40 06 b0 04 00 40 77 1b 00 40 77 1b 4d 9a 3a 00 2a 2c 0a 00 01 2a 2c 0a 00
        INTERFACE CLASS:  1e 24 07 02 00 c0 0c 90 09 00 40 4d 72 00 40 4d 72 4d da f3 00 2a 2c 0a 00 01 2a 2c 0a 00
        INTERFACE CLASS:  1e 24 07 03 00 20 0a 98 07 00 d0 14 48 00 d0 14 48 4d c8 99 00 2a 2c 0a 00 01 2a 2c 0a 00
        INTERFACE CLASS:  1e 24 07 04 00 00 08 00 06 00 00 00 2d 00 00 00 2d 4d 02 60 00 2a 2c 0a 00 01 2a 2c 0a 00
        INTERFACE CLASS:  1e 24 07 05 00 00 05 c0 03 00 00 94 11 00 00 94 11 4d 82 25 00 2a 2c 0a 00 01 2a 2c 0a 00
        INTERFACE CLASS:  1e 24 07 06 00 00 04 00 03 00 00 80 16 00 00 80 16 4d 02 18 00 15 16 05 00 01 15 16 05 00
        INTERFACE CLASS:  1e 24 07 07 00 20 03 58 02 00 a0 bb 0d 00 a0 bb 0d 4d a8 0e 00 15 16 05 00 01 15 16 05 00
        INTERFACE CLASS:  1e 24 07 08 00 80 02 e0 01 00 00 ca 08 00 00 ca 08 4d 62 09 00 15 16 05 00 01 15 16 05 00
        INTERFACE CLASS:  1e 24 07 09 00 40 01 f0 00 00 80 32 02 00 80 32 02 4d 5a 02 00 15 16 05 00 01 15 16 05 00
        INTERFACE CLASS:  1e 24 07 0a 00 40 06 b0 04 00 40 77 1b 00 40 77 1b 4d 9a 3a 00 2a 2c 0a 00 01 2a 2c 0a 00
        INTERFACE CLASS:  26 24 03 00 08 c0 0c 90 09 20 0a 98 07 00 08 00 06 40 06 b0 04 00 05 c0 03 00 04 00 03 20 03 58 02 80 02 e0 01 00
        INTERFACE CLASS:  1b 24 04 02 0a 59 55 59 32 00 00 10 00 80 00 00 aa 00 38 9b 71 10 01 00 00 00 00
        INTERFACE CLASS:  1e 24 05 01 00 40 06 b0 04 00 80 4f 12 00 80 4f 12 00 98 3a 00 40 42 0f 00 01 40 42 0f 00
        INTERFACE CLASS:  1e 24 05 02 00 c0 0c 90 09 00 80 3d 0f 00 80 3d 0f 00 d8 f3 00 40 4b 4c 00 01 40 4b 4c 00
        INTERFACE CLASS:  1e 24 05 03 00 20 0a 98 07 00 90 6a 0e 00 90 6a 0e 00 c6 99 00 d5 dc 32 00 01 d5 dc 32 00
        INTERFACE CLASS:  1e 24 05 04 00 00 08 00 06 00 00 00 09 00 00 00 09 00 00 60 00 d5 dc 32 00 01 d5 dc 32 00
        INTERFACE CLASS:  1e 24 05 05 00 00 05 c0 03 00 00 b8 0b 00 00 b8 0b 00 80 25 00 40 42 0f 00 01 40 42 0f 00
        INTERFACE CLASS:  1e 24 05 06 00 00 04 00 03 00 00 80 07 00 00 80 07 00 00 18 00 40 42 0f 00 01 40 42 0f 00
        INTERFACE CLASS:  1e 24 05 07 00 20 03 58 02 00 a0 bb 0d 00 a0 bb 0d 00 a6 0e 00 15 16 05 00 01 15 16 05 00
        INTERFACE CLASS:  1e 24 05 08 00 80 02 e0 01 00 00 ca 08 00 00 ca 08 00 60 09 00 15 16 05 00 01 15 16 05 00
        INTERFACE CLASS:  1e 24 05 09 00 40 01 f0 00 00 80 32 02 00 80 32 02 00 58 02 00 15 16 05 00 01 15 16 05 00
        INTERFACE CLASS:  1e 24 05 0a 00 40 06 b0 04 00 80 4f 12 00 80 4f 12 00 98 3a 00 40 42 0f 00 01 40 42 0f 00
        INTERFACE CLASS:  26 24 03 00 08 c0 0c 90 09 20 0a 98 07 00 08 00 06 40 06 b0 04 00 05 c0 03 00 04 00 03 20 03 58 02 80 02 e0 01 00
        INTERFACE CLASS:  06 24 0d 01 01 04


After:Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        1
      bAlternateSetting       0
      bNumEndpoints           1
      bInterfaceClass        14 Video
      bInterfaceSubClass      2 Video Streaming
      bInterfaceProtocol      0 
      iInterface              0 
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x82  EP 2 IN
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0200  1x 512 bytes
        bInterval               1
      VideoStreaming Interface Descriptor:
        bLength                            15
        bDescriptorType                    36
        bDescriptorSubtype                  1 (INPUT_HEADER)
        bNumFormats                         2
        wTotalLength                      735
        bEndPointAddress                  130
        bmInfo                              0
        bTerminalLink                       5
        bStillCaptureMethod                 2
        bTriggerSupport                     1
        bTriggerUsage                       1
        bControlSize                        1
        bmaControls( 0)                    11
        bmaControls( 1)                    11
      VideoStreaming Interface Descriptor:
        bLength                            11
        bDescriptorType                    36
        bDescriptorSubtype                  6 (FORMAT_MJPEG)
        bFormatIndex                        1
        bNumFrameDescriptors               10
        bFlags                              0
          Fixed-size samples: No
        bDefaultFrameIndex                  1
        bAspectRatioX                       0
        bAspectRatioY                       0
        bmInterlaceFlags                 0x00
          Interlaced stream or variable: No
          Fields per frame: 1 fields
          Field 1 first: No
          Field pattern: Field 1 only
        bCopyProtect                        0
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                         1
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           1600
        wHeight                          1200
        dwMinBitRate                460800000
        dwMaxBitRate                460800000
        dwMaxVideoFrameBufferSize     3840589
        dwDefaultFrameInterval         666666
        bFrameIntervalType                  1
        dwFrameInterval( 0)            666666
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                         2
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           3264
        wHeight                          2448
        dwMinBitRate                1917665280
        dwMaxBitRate                1917665280
        dwMaxVideoFrameBufferSize    15981133
        dwDefaultFrameInterval         666666
        bFrameIntervalType                  1
        dwFrameInterval( 0)            666666
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                         3
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           2592
        wHeight                          1944
        dwMinBitRate                1209323520
        dwMaxBitRate                1209323520
        dwMaxVideoFrameBufferSize    10078285
        dwDefaultFrameInterval         666666
        bFrameIntervalType                  1
        dwFrameInterval( 0)            666666
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                         4
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           2048
        wHeight                          1536
        dwMinBitRate                754974720
        dwMaxBitRate                754974720
        dwMaxVideoFrameBufferSize     6292045
        dwDefaultFrameInterval         666666
        bFrameIntervalType                  1
        dwFrameInterval( 0)            666666
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                         5
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           1280
        wHeight                           960
        dwMinBitRate                294912000
        dwMaxBitRate                294912000
        dwMaxVideoFrameBufferSize     2458189
        dwDefaultFrameInterval         666666
        bFrameIntervalType                  1
        dwFrameInterval( 0)            666666
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                         6
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           1024
        wHeight                           768
        dwMinBitRate                377487360
        dwMaxBitRate                377487360
        dwMaxVideoFrameBufferSize     1573453
        dwDefaultFrameInterval         333333
        bFrameIntervalType                  1
        dwFrameInterval( 0)            333333
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                         7
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                            800
        wHeight                           600
        dwMinBitRate                230400000
        dwMaxBitRate                230400000
        dwMaxVideoFrameBufferSize      960589
        dwDefaultFrameInterval         333333
        bFrameIntervalType                  1
        dwFrameInterval( 0)            333333
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                         8
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                            640
        wHeight                           480
        dwMinBitRate                147456000
        dwMaxBitRate                147456000
        dwMaxVideoFrameBufferSize      614989
        dwDefaultFrameInterval         333333
        bFrameIntervalType                  1
        dwFrameInterval( 0)            333333
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                         9
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                            320
        wHeight                           240
        dwMinBitRate                 36864000
        dwMaxBitRate                 36864000
        dwMaxVideoFrameBufferSize      154189
        dwDefaultFrameInterval         333333
        bFrameIntervalType                  1
        dwFrameInterval( 0)            333333
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  7 (FRAME_MJPEG)
        bFrameIndex                        10
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           1600
        wHeight                          1200
        dwMinBitRate                460800000
        dwMaxBitRate                460800000
        dwMaxVideoFrameBufferSize     3840589
        dwDefaultFrameInterval         666666
        bFrameIntervalType                  1
        dwFrameInterval( 0)            666666
      VideoStreaming Interface Descriptor:
        bLength                            38
        bDescriptorType                    36
        bDescriptorSubtype                  3 (STILL_IMAGE_FRAME)
        bEndpointAddress                    0
        bNumImageSizePatterns               8
        wWidth( 0)                       3264
        wHeight( 0)                      2448
        wWidth( 1)                       2592
        wHeight( 1)                      1944
        wWidth( 2)                       2048
        wHeight( 2)                      1536
        wWidth( 3)                       1600
        wHeight( 3)                      1200
        wWidth( 4)                       1280
        wHeight( 4)                       960
        wWidth( 5)                       1024
        wHeight( 5)                       768
        wWidth( 6)                        800
        wHeight( 6)                       600
        wWidth( 7)                        640
        wHeight( 7)                       480
        bNumCompressionPatterns             8
      VideoStreaming Interface Descriptor:
        bLength                            27
        bDescriptorType                    36
        bDescriptorSubtype                  4 (FORMAT_UNCOMPRESSED)
        bFormatIndex                        2
        bNumFrameDescriptors               10
        guidFormat                            {32595559-0000-0010-8000-00aa00389b71}
        bBitsPerPixel                      16
        bDefaultFrameIndex                  1
        bAspectRatioX                       0
        bAspectRatioY                       0
        bmInterlaceFlags                 0x00
          Interlaced stream or variable: No
          Fields per frame: 2 fields
          Field 1 first: No
          Field pattern: Field 1 only
        bCopyProtect                        0
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                         1
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           1600
        wHeight                          1200
        dwMinBitRate                307200000
        dwMaxBitRate                307200000
        dwMaxVideoFrameBufferSize     3840000
        dwDefaultFrameInterval        1000000
        bFrameIntervalType                  1
        dwFrameInterval( 0)           1000000
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                         2
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           3264
        wHeight                          2448
        dwMinBitRate                255688704
        dwMaxBitRate                255688704
        dwMaxVideoFrameBufferSize    15980544
        dwDefaultFrameInterval        5000000
        bFrameIntervalType                  1
        dwFrameInterval( 0)           5000000
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                         3
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           2592
        wHeight                          1944
        dwMinBitRate                241864704
        dwMaxBitRate                241864704
        dwMaxVideoFrameBufferSize    10077696
        dwDefaultFrameInterval        3333333
        bFrameIntervalType                  1
        dwFrameInterval( 0)           3333333
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                         4
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           2048
        wHeight                          1536
        dwMinBitRate                150994944
        dwMaxBitRate                150994944
        dwMaxVideoFrameBufferSize     6291456
        dwDefaultFrameInterval        3333333
        bFrameIntervalType                  1
        dwFrameInterval( 0)           3333333
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                         5
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           1280
        wHeight                           960
        dwMinBitRate                196608000
        dwMaxBitRate                196608000
        dwMaxVideoFrameBufferSize     2457600
        dwDefaultFrameInterval        1000000
        bFrameIntervalType                  1
        dwFrameInterval( 0)           1000000
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                         6
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           1024
        wHeight                           768
        dwMinBitRate                125829120
        dwMaxBitRate                125829120
        dwMaxVideoFrameBufferSize     1572864
        dwDefaultFrameInterval        1000000
        bFrameIntervalType                  1
        dwFrameInterval( 0)           1000000
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                         7
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                            800
        wHeight                           600
        dwMinBitRate                230400000
        dwMaxBitRate                230400000
        dwMaxVideoFrameBufferSize      960000
        dwDefaultFrameInterval         333333
        bFrameIntervalType                  1
        dwFrameInterval( 0)            333333
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                         8
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                            640
        wHeight                           480
        dwMinBitRate                147456000
        dwMaxBitRate                147456000
        dwMaxVideoFrameBufferSize      614400
        dwDefaultFrameInterval         333333
        bFrameIntervalType                  1
        dwFrameInterval( 0)            333333
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                         9
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                            320
        wHeight                           240
        dwMinBitRate                 36864000
        dwMaxBitRate                 36864000
        dwMaxVideoFrameBufferSize      153600
        dwDefaultFrameInterval         333333
        bFrameIntervalType                  1
        dwFrameInterval( 0)            333333
      VideoStreaming Interface Descriptor:
        bLength                            30
        bDescriptorType                    36
        bDescriptorSubtype                  5 (FRAME_UNCOMPRESSED)
        bFrameIndex                        10
        bmCapabilities                   0x00
          Still image unsupported
        wWidth                           1600
        wHeight                          1200
        dwMinBitRate                307200000
        dwMaxBitRate                307200000
        dwMaxVideoFrameBufferSize     3840000
        dwDefaultFrameInterval        1000000
        bFrameIntervalType                  1
        dwFrameInterval( 0)           1000000
      VideoStreaming Interface Descriptor:
        bLength                            38
        bDescriptorType                    36
        bDescriptorSubtype                  3 (STILL_IMAGE_FRAME)
        bEndpointAddress                    0
        bNumImageSizePatterns               8
        wWidth( 0)                       3264
        wHeight( 0)                      2448
        wWidth( 1)                       2592
        wHeight( 1)                      1944
        wWidth( 2)                       2048
        wHeight( 2)                      1536
        wWidth( 3)                       1600
        wHeight( 3)                      1200
        wWidth( 4)                       1280
        wHeight( 4)                       960
        wWidth( 5)                       1024
        wHeight( 5)                       768
        wWidth( 6)                        800
        wHeight( 6)                       600
        wWidth( 7)                        640
        wHeight( 7)                       480
        bNumCompressionPatterns             8
      VideoStreaming Interface Descriptor:
        bLength                             6
        bDescriptorType                    36
        bDescriptorSubtype                 13 (COLORFORMAT)
        bColorPrimaries                     1 (BT.709,sRGB)
        bTransferCharacteristics            1 (BT.709)
        bMatrixCoefficients                 4 (SMPTE 170M (BT.601))


