### PR TITLE
[WIP] Add support for UAC3 descriptors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,8 @@ lsusb_SOURCES = \
 	lsusb.c lsusb.h \
 	lsusb-t.c \
 	list.h \
+	desc-defs.c desc-defs.h \
+	desc-dump.c desc-dump.h \
 	names.c names.h \
 	usb-spec.h \
 	usbmisc.c usbmisc.h

--- a/desc-defs.c
+++ b/desc-defs.c
@@ -61,9 +61,28 @@ static const char * const uac2_input_term_bmcontrols[] = {
 	NULL
 };
 
+/* USB DCD for Audio Devices Release 3.0: Section 4.5.2.1, Table 4-16, pp67 */
+static const char * const uac3_input_term_bmcontrols[] = {
+	"Insertion",
+	"Overload",
+	"Underflow",
+	"Overflow",
+	"Underflow",
+	NULL
+};
+
 static const char * const uac2_output_term_bmcontrols[] = {
 	"Copy Protect",
 	"Connector",
+	"Overload",
+	"Underflow",
+	"Overflow",
+	NULL
+};
+
+/* USB DCD for Audio Devices Release 3.0: Section 4.5.2.2, Table 4-17, pp69 */
+static const char * const uac3_output_term_bmcontrols[] = {
+	"Insertion",
 	"Overload",
 	"Underflow",
 	"Overflow",
@@ -77,9 +96,23 @@ static const char * const uac2_mixer_unit_bmcontrols[] = {
 	NULL
 };
 
+/* USB DCD for Audio Devices Release 3.0: Section 4.5.2.5, Table 4-29, pp79 */
+static const char * const uac3_mixer_unit_bmcontrols[] = {
+	"Underflow",
+	"Overflow",
+	NULL
+};
+
 static const char * const uac2_extension_unit_bmcontrols[] = {
 	"Enable",
 	"Cluster",
+	"Underflow",
+	"Overflow",
+	NULL
+};
+
+/* USB DCD for Audio Devices Release 3.0: Section 4.5.2.11, Table 4-42, pp91 */
+static const char * const uac3_extension_unit_bmcontrols[] = {
 	"Underflow",
 	"Overflow",
 	NULL
@@ -146,10 +179,18 @@ static const struct desc desc_audio_2_ac_header[] = {
 			.bmcontrol = uac2_interface_header_bmcontrols },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2 Class-Specific AC Interface Descriptor; Table 4-15. */
+static const struct desc desc_audio_3_ac_header[] = {
+	{ .field = "bCategory",    .size = 1, .type = DESC_CONSTANT },
+	{ .field = "wTotalLength", .size = 2, .type = DESC_NUMBER },
+	{ .field = "bmControls",   .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_interface_header_bmcontrols },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_header[3] = {
 	desc_audio_1_ac_header,
 	desc_audio_2_ac_header,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_header,
 };
 
 /** UAC2: 4.7.2.10 Effect Unit Descriptor; Table 4-15. */
@@ -162,10 +203,20 @@ static const struct desc desc_audio_2_ac_effect_unit[] = {
 	{ .field = "iEffects",    .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.9 Effect Unit Descriptor; Table 4-33. */
+static const struct desc desc_audio_3_ac_effect_unit[] = {
+	{ .field = "bUnitID",          .size = 1, .type = DESC_NUMBER },
+	{ .field = "wEffectType",      .size = 2, .type = DESC_CONSTANT },
+	{ .field = "bSourceID",        .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bmaControls",      .size = 4, .type = DESC_BITMAP,
+			.array = { .array = true } },
+	{ .field = "wEffectsDescrStr", .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_effect_unit[3] = {
 	NULL, /* UAC1 not supported */
 	desc_audio_2_ac_effect_unit,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_effect_unit,
 };
 
 
@@ -196,10 +247,24 @@ static const struct desc desc_audio_2_ac_input_terminal[] = {
 	{ .field = "iTerminal",       .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.1 Input Terminal Descriptor; Table 4-16. */
+static const struct desc desc_audio_3_ac_input_terminal[] = {
+	{ .field = "bTerminalID",        .size = 1, .type = DESC_NUMBER },
+	{ .field = "wTerminalType",      .size = 2, .type = DESC_TERMINAL_STR },
+	{ .field = "bAssocTerminal",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bCSourceID",         .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",         .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac3_input_term_bmcontrols },
+	{ .field = "wClusterDescrID",    .size = 2, .type = DESC_NUMBER },
+	{ .field = "wExTerminalDescrID", .size = 2, .type = DESC_NUMBER },
+	{ .field = "wConnectorsDescrID", .size = 2, .type = DESC_NUMBER },
+	{ .field = "wTerminalDescrStr",  .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_input_terminal[3] = {
 	desc_audio_1_ac_input_terminal,
 	desc_audio_2_ac_input_terminal,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_input_terminal,
 };
 
 
@@ -224,10 +289,55 @@ static const struct desc desc_audio_2_ac_output_terminal[] = {
 	{ .field = "iTerminal",      .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.2 Output Terminal Descriptor; Table 4-17. */
+static const struct desc desc_audio_3_ac_output_terminal[] = {
+	{ .field = "bTerminalID",        .size = 1, .type = DESC_NUMBER },
+	{ .field = "wTerminalType",      .size = 2, .type = DESC_TERMINAL_STR },
+	{ .field = "bAssocTerminal",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bSourceID",          .size = 1, .type = DESC_NUMBER },
+	{ .field = "bCSourceID",         .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",         .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac3_output_term_bmcontrols },
+	{ .field = "wExTerminalDescrID", .size = 2, .type = DESC_NUMBER },
+	{ .field = "wConnectorsDescrID", .size = 2, .type = DESC_NUMBER },
+	{ .field = "wTerminalDescrStr",  .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_output_terminal[3] = {
 	desc_audio_1_ac_output_terminal,
 	desc_audio_2_ac_output_terminal,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_output_terminal,
+};
+
+
+/** UAC3: 4.5.2.3.1 Extended Terminal Header Descriptor; Table 4-18. */
+static const struct desc desc_audio_3_ac_extended_terminal_header[] = {
+	{ .field = "wDescriptorID", .size = 2, .type = DESC_NUMBER },
+	{ .field = "bNrChannels",   .size = 1, .type = DESC_NUMBER },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_extended_terminal[3] = {
+	NULL, /* UAC1 not supported */
+	NULL, /* UAC2 not supported */
+	desc_audio_3_ac_extended_terminal_header,
+};
+
+
+/** UAC3: 4.5.2.15 Power Domain Descriptor; Table 4-46. */
+static const struct desc desc_audio_3_ac_power_domain[] = {
+	{ .field = "bPowerDomainID",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "waRecoveryTime(1)", .size = 2, .type = DESC_NUMBER },
+	{ .field = "waRecoveryTime(2)", .size = 2, .type = DESC_NUMBER },
+	{ .field = "bNrEntities",       .size = 1, .type = DESC_NUMBER },
+	{ .field = "baEntityID",        .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrEntities" } },
+	{ .field = "wPDomainDescrStr",  .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_power_domain[3] = {
+	NULL, /* UAC1 not supported */
+	NULL, /* UAC2 not supported */
+	desc_audio_3_ac_power_domain,
 };
 
 
@@ -267,10 +377,24 @@ static const struct desc desc_audio_2_ac_mixer_unit[] = {
 	{ .field = "iMixer",         .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.5 Mixer Unit Descriptor; Table 4-29. */
+static const struct desc desc_audio_3_ac_mixer_unit[] = {
+	{ .field = "bUnitID",        .size = 1, .type = DESC_NUMBER },
+	{ .field = "bNrInPins",      .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",     .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "wClusterDescrID",.size = 2, .type = DESC_NUMBER },
+	{ .field = "bmMixerControls",.size = 1, .type = DESC_BITMAP,
+			.array = { .array = true } },
+	{ .field = "bmControls",     .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac3_mixer_unit_bmcontrols },
+	{ .field = "wMixerDescrStr", .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_mixer_unit[3] = {
 	desc_audio_1_ac_mixer_unit,
 	desc_audio_2_ac_mixer_unit,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_mixer_unit,
 };
 
 
@@ -294,10 +418,21 @@ static const struct desc desc_audio_2_ac_selector_unit[] = {
 	{ .field = "iSelector",  .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.6 Selector Unit Descriptor; Table 4-30. */
+static const struct desc desc_audio_3_ac_selector_unit[] = {
+	{ .field = "bUnitID",           .size = 1, .type = DESC_NUMBER },
+	{ .field = "bNrInPins",         .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",        .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bmControls",        .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_selector_bmcontrols },
+	{ .field = "wSelectorDescrStr", .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_selector_unit[3] = {
 	desc_audio_1_ac_selector_unit,
 	desc_audio_2_ac_selector_unit,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_selector_unit,
 };
 
 
@@ -339,10 +474,22 @@ static const struct desc desc_audio_2_ac_processing_unit[] = {
 			.array = { .array = true } },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.10 Processing Unit Descriptor; Table 4-38. */
+static const struct desc desc_audio_3_ac_processing_unit[] = {
+	{ .field = "bUnitID",             .size = 1, .type = DESC_NUMBER },
+	{ .field = "wProcessType",        .size = 2, .type = DESC_CONSTANT },
+	{ .field = "bNrInPins",           .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",          .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "wProcessingDescrStr", .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = "Process-specific",    .size = 1, .type = DESC_BITMAP,
+			.array = { .array = true } },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_processing_unit[3] = {
 	desc_audio_1_ac_processing_unit,
 	desc_audio_2_ac_processing_unit,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_processing_unit,
 };
 
 
@@ -365,10 +512,19 @@ static const struct desc desc_audio_2_ac_feature_unit[] = {
 	{ .field = "iFeature",    .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.7 Feature Unit Descriptor; Table 4-31. */
+static const struct desc desc_audio_3_ac_feature_unit[] = {
+	{ .field = "bUnitID",          .size = 1, .type = DESC_NUMBER },
+	{ .field = "bSourceID",        .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmaControls",      .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac_feature_unit_bmcontrols, .array = { .array = true } },
+	{ .field = "wFeatureDescrStr", .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_feature_unit[3] = {
 	desc_audio_1_ac_feature_unit,
 	desc_audio_2_ac_feature_unit,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_feature_unit,
 };
 
 
@@ -405,10 +561,23 @@ static const struct desc desc_audio_2_ac_extension_unit[] = {
 	{ .field = "iExtension",      .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.11 Extension Unit Descriptor; Table 4-42. */
+static const struct desc desc_audio_3_ac_extension_unit[] = {
+	{ .field = "bUnitID",            .size = 1, .type = DESC_NUMBER },
+	{ .field = "wExtensionCode",     .size = 2, .type = DESC_CONSTANT },
+	{ .field = "bNrInPins",          .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",         .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "wExtensionDescrStr", .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = "bmControls",         .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac3_extension_unit_bmcontrols },
+	{ .field = "wClusterDescrID",    .size = 2, .type = DESC_NUMBER },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_extension_unit[3] = {
 	desc_audio_1_ac_extension_unit,
 	desc_audio_2_ac_extension_unit,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_extension_unit,
 };
 
 
@@ -435,6 +604,16 @@ static void desc_snowflake_dump_uac2_clk_src_bmattr(
 			(value & 0x4) ? uac3_clk_src_bmattr[3] : "");
 }
 
+/** Special rendering function for UAC3 clock source bmAttributes */
+static void desc_snowflake_dump_uac3_clk_src_bmattr(
+		unsigned long long value,
+		unsigned int indent)
+{
+	printf(" %s clock %s\n",
+			uac3_clk_src_bmattr[(value & 0x1)],
+			uac3_clk_src_bmattr[0x2 | ((value & 0x2) >> 1)]);
+}
+
 /** UAC2: 4.7.2.1 Clock Source Descriptor; Table 4-6. */
 static const struct desc desc_audio_2_ac_clock_source[] = {
 	{ .field = "bClockID",       .size = 1, .type = DESC_CONSTANT },
@@ -446,10 +625,21 @@ static const struct desc desc_audio_2_ac_clock_source[] = {
 	{ .field = "iClockSource",   .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.12 Clock Source Descriptor; Table 4-43. */
+static const struct desc desc_audio_3_ac_clock_source[] = {
+	{ .field = "bClockID",           .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmAttributes",       .size = 1, .type = DESC_SNOWFLAKE,
+			.snowflake = desc_snowflake_dump_uac3_clk_src_bmattr },
+	{ .field = "bmControls",         .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_clock_source_bmcontrols },
+	{ .field = "bReferenceTerminal", .size = 1, .type = DESC_NUMBER },
+	{ .field = "wClockSourceStr",    .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_clock_source[3] = {
 	NULL, /* UAC1 not supported */
 	desc_audio_2_ac_clock_source,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_clock_source,
 };
 
 
@@ -464,10 +654,21 @@ static const struct desc desc_audio_2_ac_clock_selector[] = {
 	{ .field = "iClockSelector", .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.13 Clock Selector Descriptor; Table 4-44. */
+static const struct desc desc_audio_3_ac_clock_selector[] = {
+	{ .field = "bClockID",           .size = 1, .type = DESC_NUMBER },
+	{ .field = "bNrInPins",          .size = 1, .type = DESC_NUMBER },
+	{ .field = "baCSourceID",        .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bmControls",         .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_clock_selector_bmcontrols },
+	{ .field = "wCSelectorDescrStr", .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_clock_selector[3] = {
 	NULL, /* UAC1 not supported */
 	desc_audio_2_ac_clock_selector,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_clock_selector,
 };
 
 
@@ -480,10 +681,19 @@ static const struct desc desc_audio_2_ac_clock_multiplier[] = {
 	{ .field = "iClockMultiplier", .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.14 Clock Multiplier Descriptor; Table 4-45. */
+static const struct desc desc_audio_3_ac_clock_multiplier[] = {
+	{ .field = "bClockID",             .size = 1, .type = DESC_NUMBER },
+	{ .field = "bCSourceID",           .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",           .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_clock_multiplier_bmcontrols },
+	{ .field = "wCMultiplierDescrStr", .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_clock_multiplier[3] = {
 	NULL, /* UAC1 not supported */
 	desc_audio_2_ac_clock_multiplier,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_clock_multiplier,
 };
 
 
@@ -496,16 +706,31 @@ static const struct desc desc_audio_2_ac_sample_rate_converter[] = {
 	{ .field = "iSRC",          .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.5.2.8 Sampling Rate Converter Descriptor; Table 4-32. */
+static const struct desc desc_audio_3_ac_sample_rate_converter[] = {
+	{ .field = "bUnitID",       .size = 1, .type = DESC_NUMBER },
+	{ .field = "bSourceID",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bCSourceInID",  .size = 1, .type = DESC_NUMBER },
+	{ .field = "bCSourceOutID", .size = 1, .type = DESC_NUMBER },
+	{ .field = "wSRCDescrStr",  .size = 2, .type = DESC_CS_STR_DESC_ID },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_ac_sample_rate_converter[3] = {
 	NULL, /* UAC1 not supported */
 	desc_audio_2_ac_sample_rate_converter,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_ac_sample_rate_converter,
 };
 
 
 static const char * const uac2_as_interface_bmcontrols[] = {
 	"Active Alternate Setting",
 	"Valid Alternate Setting",
+	NULL
+};
+static const char * const uac3_as_interface_bmcontrols[] = {
+	"Active Alternate Setting",
+	"Valid Alternate Setting",
+	"Audio Data Format Control",
 	NULL
 };
 static const char * const audio_data_format_type_i[] = {
@@ -591,10 +816,23 @@ static const struct desc desc_audio_2_as_interface[] = {
 	{ .field = "iChannelNames",   .size = 1, .type = DESC_STR_DESC_INDEX },
 	{ .field = NULL }
 };
+/** UAC3: 4.7.2 Class-Specific AS Interface Descriptor; Table 4-49. */
+static const struct desc desc_audio_3_as_interface[] = {
+	{ .field = "bTerminalLink",   .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",      .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac3_as_interface_bmcontrols },
+	{ .field = "wClusterDescrID", .size = 2, .type = DESC_NUMBER },
+	{ .field = "bmFormats",       .size = 8, .type = DESC_BITMAP },
+	{ .field = "bSubslotSize",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "bBitResolution",  .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmAuxProtocols",  .size = 2, .type = DESC_BITMAP },
+	{ .field = "bControlSize",    .size = 1, .type = DESC_NUMBER },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_as_interface[3] = {
 	desc_audio_1_as_interface,
 	desc_audio_2_as_interface,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_as_interface,
 };
 
 
@@ -640,8 +878,17 @@ static const struct desc desc_audio_2_as_isochronous_audio_data_endpoint[] = {
 	{ .field = "wLockDelay",      .size = 2, .type = DESC_NUMBER },
 	{ .field = NULL }
 };
+/** UAC3: 4.8.1.2 Class-Specific AS Isochronous Audio Data Endpoint Descriptor; Table 4-52. */
+static const struct desc desc_audio_3_as_isochronous_audio_data_endpoint[] = {
+	{ .field = "bmControls",      .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_as_isochronous_audio_data_endpoint_bmcontrols },
+	{ .field = "bLockDelayUnits", .size = 1, .type = DESC_NUMBER_STRINGS,
+			.number_strings = uac_as_isochronous_audio_data_endpoint_blockdelayunits },
+	{ .field = "wLockDelay",      .size = 2, .type = DESC_NUMBER },
+	{ .field = NULL }
+};
 const struct desc * const desc_audio_as_isochronous_audio_data_endpoint[3] = {
 	desc_audio_1_as_isochronous_audio_data_endpoint,
 	desc_audio_2_as_isochronous_audio_data_endpoint,
-	NULL, /* UAC3 not implemented yet */
+	desc_audio_3_as_isochronous_audio_data_endpoint,
 };

--- a/desc-defs.c
+++ b/desc-defs.c
@@ -892,3 +892,19 @@ const struct desc * const desc_audio_as_isochronous_audio_data_endpoint[3] = {
 	desc_audio_2_as_isochronous_audio_data_endpoint,
 	desc_audio_3_as_isochronous_audio_data_endpoint,
 };
+
+
+/** USB3: 9.6.2.7 Configuration Summary Descriptor; Table 9-21. */
+const struct desc desc_usb3_dc_configuration_summary[] = {
+	{ .field = "bLength",             .size = 1, .type = DESC_NUMBER },
+	{ .field = "bDescriptorType",     .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bDevCapabilityType",  .size = 1, .type = DESC_NUMBER },
+	{ .field = "bcdVersion",          .size = 2, .type = DESC_BCD },
+	{ .field = "bClass",              .size = 1, .type = DESC_NUMBER },
+	{ .field = "bSubClass",           .size = 1, .type = DESC_NUMBER },
+	{ .field = "bProtocol",           .size = 1, .type = DESC_NUMBER },
+	{ .field = "bConfigurationCount", .size = 1, .type = DESC_NUMBER },
+	{ .field = "bConfigurationIndex", .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bConfigurationCount" } },
+	{ .field = NULL }
+};

--- a/desc-defs.c
+++ b/desc-defs.c
@@ -1,0 +1,647 @@
+/*****************************************************************************/
+
+/*
+ *      desc-defs.c  --  USB descriptor definitions
+ *
+ *      Copyright (C) 2017 Michael Drake <michael.drake@codethink.co.uk>
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ */
+
+/*****************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "desc-defs.h"
+
+static const char * const uac2_interface_header_bmcontrols[] = {
+	"Latency control",
+	NULL
+};
+
+static const char * const uac_feature_unit_bmcontrols[] = {
+	"Mute",
+	"Volume",
+	"Bass",
+	"Mid",
+	"Treble",
+	"Graphic Equalizer",
+	"Automatic Gain",
+	"Delay",
+	"Bass Boost",
+	"Loudness",
+	"Input gain",
+	"Input gain pad",
+	"Phase inverter",
+	NULL
+};
+
+static const char * const uac2_input_term_bmcontrols[] = {
+	"Copy Protect",
+	"Connector",
+	"Overload",
+	"Cluster",
+	"Underflow",
+	"Overflow",
+	NULL
+};
+
+static const char * const uac2_output_term_bmcontrols[] = {
+	"Copy Protect",
+	"Connector",
+	"Overload",
+	"Underflow",
+	"Overflow",
+	NULL
+};
+
+static const char * const uac2_mixer_unit_bmcontrols[] = {
+	"Cluster",
+	"Underflow",
+	"Overflow",
+	NULL
+};
+
+static const char * const uac2_extension_unit_bmcontrols[] = {
+	"Enable",
+	"Cluster",
+	"Underflow",
+	"Overflow",
+	NULL
+};
+
+static const char * const uac2_clock_source_bmcontrols[] = {
+	"Clock Frequency",
+	"Clock Validity",
+	NULL
+};
+
+static const char * const uac2_clock_selector_bmcontrols[] = {
+	"Clock Selector",
+	NULL
+};
+
+static const char * const uac2_clock_multiplier_bmcontrols[] = {
+	"Clock Numerator",
+	"Clock Denominator",
+	NULL
+};
+
+static const char * const uac2_selector_bmcontrols[] = {
+	"Selector",
+	NULL
+};
+
+static const char * const uac1_channel_names[] = {
+	"Left Front (L)", "Right Front (R)", "Center Front (C)",
+	"Low Frequency Enhancement (LFE)", "Left Surround (LS)",
+	"Right Surround (RS)", "Left of Center (LC)", "Right of Center (RC)",
+	"Surround (S)", "Side Left (SL)", "Side Right (SR)", "Top (T)"
+};
+
+static const char * const uac2_channel_names[] = {
+	"Front Left (FL)", "Front Right (FR)", "Front Center (FC)",
+	"Low Frequency Effects (LFE)", "Back Left (BL)", "Back Right (BR)",
+	"Front Left of Center (FLC)", "Front Right of Center (FRC)",
+	"Back Center (BC)", "Side Left (SL)", "Side Right (SR)",
+	"Top Center (TC)", "Top Front Left (TFL)", "Top Front Center (TFC)",
+	"Top Front Right (TFR)", "Top Back Left (TBL)", "Top Back Center (TBC)",
+	"Top Back Right (TBR)", "Top Front Left of Center (TFLC)",
+	"Top Front Right of Center (TFRC)", "Left Low Frequency Effects (LLFE)",
+	"Right Low Frequency Effects (RLFE)", "Top Side Left (TSL)",
+	"Top Side Right (TSR)", "Bottom Center (BC)",
+	"Back Left of Center (BLC)", "Back Right of Center (BRC)"
+};
+
+/** UAC1: 4.3.2 Class-Specific AC Interface Descriptor; Table 4-2. */
+static const struct desc desc_audio_1_ac_header[] = {
+	{ .field = "bcdADC",        .size = 2, .type = DESC_BCD },
+	{ .field = "wTotalLength",  .size = 2, .type = DESC_CONSTANT },
+	{ .field = "bInCollection", .size = 1, .type = DESC_CONSTANT },
+	{ .field = "baInterfaceNr", .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true } },
+	{ .field = NULL }
+};
+/** UAC2: 4.7.2 Class-Specific AC Interface Descriptor; Table 4-5. */
+static const struct desc desc_audio_2_ac_header[] = {
+	{ .field = "bcdADC",       .size = 2, .type = DESC_BCD },
+	{ .field = "bCategory",    .size = 1, .type = DESC_CONSTANT },
+	{ .field = "wTotalLength", .size = 2, .type = DESC_NUMBER },
+	{ .field = "bmControls",   .size = 1, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_interface_header_bmcontrols },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_header[3] = {
+	desc_audio_1_ac_header,
+	desc_audio_2_ac_header,
+	NULL, /* UAC3 not implemented yet */
+};
+
+/** UAC2: 4.7.2.10 Effect Unit Descriptor; Table 4-15. */
+static const struct desc desc_audio_2_ac_effect_unit[] = {
+	{ .field = "bUnitID",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "wEffectType", .size = 2, .type = DESC_CONSTANT },
+	{ .field = "bSourceID",   .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bmaControls", .size = 4, .type = DESC_BITMAP,
+			.array = { .array = true } },
+	{ .field = "iEffects",    .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_effect_unit[3] = {
+	NULL, /* UAC1 not supported */
+	desc_audio_2_ac_effect_unit,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC1: 4.3.2.1 Input Terminal Descriptor; Table 4-3. */
+static const struct desc desc_audio_1_ac_input_terminal[] = {
+	{ .field = "bTerminalID",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "wTerminalType",  .size = 2, .type = DESC_TERMINAL_STR },
+	{ .field = "bAssocTerminal", .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bNrChannels",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "wChannelConfig", .size = 2, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac1_channel_names, .count = 12 } },
+	{ .field = "iChannelNames",  .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "iTerminal",      .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+/** UAC2: 4.7.2.4 Input Terminal Descriptor; Table 4-9. */
+static const struct desc desc_audio_2_ac_input_terminal[] = {
+	{ .field = "bTerminalID",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "wTerminalType",   .size = 2, .type = DESC_TERMINAL_STR },
+	{ .field = "bAssocTerminal",  .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bCSourceID",      .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bNrChannels",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmChannelConfig", .size = 4, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac2_channel_names, .count = 26 } },
+	{ .field = "iChannelNames",   .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "bmControls",      .size = 2, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_input_term_bmcontrols },
+	{ .field = "iTerminal",       .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_input_terminal[3] = {
+	desc_audio_1_ac_input_terminal,
+	desc_audio_2_ac_input_terminal,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC1: 4.3.2.2 Output Terminal Descriptor; Table 4-4. */
+static const struct desc desc_audio_1_ac_output_terminal[] = {
+	{ .field = "bTerminalID",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "wTerminalType",  .size = 2, .type = DESC_TERMINAL_STR },
+	{ .field = "bAssocTerminal", .size = 1, .type = DESC_NUMBER },
+	{ .field = "bSourceID",      .size = 1, .type = DESC_NUMBER },
+	{ .field = "iTerminal",      .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+/** UAC2: 4.7.2.5 Output Terminal Descriptor; Table 4-10. */
+static const struct desc desc_audio_2_ac_output_terminal[] = {
+	{ .field = "bTerminalID",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "wTerminalType",  .size = 2, .type = DESC_TERMINAL_STR },
+	{ .field = "bAssocTerminal", .size = 1, .type = DESC_NUMBER },
+	{ .field = "bSourceID",      .size = 1, .type = DESC_NUMBER },
+	{ .field = "bCSourceID",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",     .size = 2, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_output_term_bmcontrols },
+	{ .field = "iTerminal",      .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_output_terminal[3] = {
+	desc_audio_1_ac_output_terminal,
+	desc_audio_2_ac_output_terminal,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC1: 4.3.2.3 Mixer Unit Descriptor; Table 4-5. */
+static const struct desc desc_audio_1_ac_mixer_unit[] = {
+	{ .field = "bUnitID",        .size = 1, .type = DESC_NUMBER },
+	{ .field = "bNrInPins",      .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",     .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bNrChannels",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "wChannelConfig", .size = 2, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac1_channel_names, .count = 12 } },
+	{ .field = "iChannelNames",  .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "bmControls",     .size = 1, .type = DESC_BITMAP,
+			.array = { .array = true, .bits = true,
+					.length_field1 = "bNrInPins",
+					.length_field2 = "bNrChannels" } },
+	{ .field = "iMixer",         .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+/** UAC2: 4.7.2.6 Mixer Unit Descriptor; Table 4-11. */
+static const struct desc desc_audio_2_ac_mixer_unit[] = {
+	{ .field = "bUnitID",        .size = 1, .type = DESC_NUMBER },
+	{ .field = "bNrInPins",      .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",     .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bNrChannels",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmChannelConfig",.size = 4, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac2_channel_names, .count = 26 } },
+	{ .field = "iChannelNames",  .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "bmMixerControls",.size = 1, .type = DESC_BITMAP,
+			.array = { .array = true, .bits = true,
+					.length_field1 = "bNrInPins",
+					.length_field2 = "bNrChannels" } },
+	{ .field = "bmControls",     .size = 1, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_mixer_unit_bmcontrols },
+	{ .field = "iMixer",         .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_mixer_unit[3] = {
+	desc_audio_1_ac_mixer_unit,
+	desc_audio_2_ac_mixer_unit,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC1: 4.3.2.4 Selector Unit Descriptor; Table 4-6. */
+static const struct desc desc_audio_1_ac_selector_unit[] = {
+	{ .field = "bUnitID",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "bNrInPins",  .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID", .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "iSelector",  .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+/** UAC2: 4.7.2.7 Selector Unit Descriptor; Table 4-12. */
+static const struct desc desc_audio_2_ac_selector_unit[] = {
+	{ .field = "bUnitID",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "bNrInPins",  .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID", .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bmControls", .size = 1, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_selector_bmcontrols },
+	{ .field = "iSelector",  .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_selector_unit[3] = {
+	desc_audio_1_ac_selector_unit,
+	desc_audio_2_ac_selector_unit,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC1: 4.3.2.6 Processing Unit Descriptor; Table 4-8. */
+static const struct desc desc_audio_1_ac_processing_unit[] = {
+	{ .field = "bUnitID",          .size = 1, .type = DESC_NUMBER },
+	{ .field = "wProcessType",     .size = 2, .type = DESC_CONSTANT },
+	{ .field = "bNrInPins",        .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",       .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bNrChannels",      .size = 1, .type = DESC_NUMBER },
+	{ .field = "wChannelConfig",   .size = 2, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac1_channel_names, .count = 12 } },
+	{ .field = "iChannelNames",    .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "bControlSize",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",       .size = 1, .type = DESC_BITMAP,
+			.array = { .array = true, .length_field1 = "bControlSize" } },
+	{ .field = "iProcessing",      .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "Process-specific", .size = 1, .type = DESC_BITMAP,
+			.array = { .array = true } },
+	{ .field = NULL }
+};
+/** UAC2: 4.7.2.11 Processing Unit Descriptor; Table 4-20. */
+static const struct desc desc_audio_2_ac_processing_unit[] = {
+	{ .field = "bUnitID",          .size = 1, .type = DESC_NUMBER },
+	{ .field = "wProcessType",     .size = 2, .type = DESC_CONSTANT },
+	{ .field = "bNrInPins",        .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",       .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bNrChannels",      .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmChannelConfig",  .size = 4, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac2_channel_names, .count = 26 } },
+	{ .field = "iChannelNames",    .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "bControlSize",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",       .size = 2, .type = DESC_BITMAP,
+			.array = { .array = true, .length_field1 = "bControlSize" } },
+	{ .field = "iProcessing",      .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "Process-specific", .size = 1, .type = DESC_BITMAP,
+			.array = { .array = true } },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_processing_unit[3] = {
+	desc_audio_1_ac_processing_unit,
+	desc_audio_2_ac_processing_unit,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC1: 4.3.2.5 Feature Unit Descriptor; Table 4-7. */
+static const struct desc desc_audio_1_ac_feature_unit[] = {
+	{ .field = "bUnitID",      .size = 1,                    .type = DESC_NUMBER },
+	{ .field = "bSourceID",    .size = 1,                    .type = DESC_CONSTANT },
+	{ .field = "bControlSize", .size = 1,                    .type = DESC_NUMBER },
+	{ .field = "bmaControls",  .size_field = "bControlSize", .type = DESC_BMCONTROL_1,
+			.bmcontrol = uac_feature_unit_bmcontrols, .array = { .array = true } },
+	{ .field = "iFeature",     .size = 1,                    .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+/** UAC2: 4.7.2.8 Feature Unit Descriptor; Table 4-13. */
+static const struct desc desc_audio_2_ac_feature_unit[] = {
+	{ .field = "bUnitID",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bSourceID",   .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bmaControls", .size = 4, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac_feature_unit_bmcontrols, .array = { .array = true } },
+	{ .field = "iFeature",    .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_feature_unit[3] = {
+	desc_audio_1_ac_feature_unit,
+	desc_audio_2_ac_feature_unit,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC1: 4.3.2.7 Extension Unit Descriptor; Table 4-15. */
+static const struct desc desc_audio_1_ac_extension_unit[] = {
+	{ .field = "bUnitID",        .size = 1, .type = DESC_NUMBER },
+	{ .field = "wExtensionCode", .size = 2, .type = DESC_CONSTANT },
+	{ .field = "bNrInPins",      .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",     .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bNrChannels",    .size = 1, .type = DESC_NUMBER },
+	{ .field = "wChannelConfig", .size = 2, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac1_channel_names, .count = 12 } },
+	{ .field = "iChannelNames",  .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "bControlSize",   .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",     .size = 1, .type = DESC_BITMAP,
+			.array = { .array = true, .length_field1 = "bControlSize" } },
+	{ .field = "iExtension",     .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+/** UAC2: 4.7.2.12 Extension Unit Descriptor; Table 4-24. */
+static const struct desc desc_audio_2_ac_extension_unit[] = {
+	{ .field = "bUnitID",         .size = 1, .type = DESC_NUMBER },
+	{ .field = "wExtensionCode",  .size = 2, .type = DESC_CONSTANT },
+	{ .field = "bNrInPins",       .size = 1, .type = DESC_NUMBER },
+	{ .field = "baSourceID",      .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bNrChannels",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmChannelConfig", .size = 4, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac2_channel_names, .count = 26 } },
+	{ .field = "iChannelNames",   .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = "bmControls",      .size = 1, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_extension_unit_bmcontrols },
+	{ .field = "iExtension",      .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_extension_unit[3] = {
+	desc_audio_1_ac_extension_unit,
+	desc_audio_2_ac_extension_unit,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+static const char * const uac2_clk_src_bmattr[] = {
+	"External",
+	"Internal fixed",
+	"Internal variable",
+	"Internal programmable"
+};
+static const char * const uac3_clk_src_bmattr[] = {
+	"External",
+	"Internal",
+	"(asynchronous)",
+	"(synchronized to SOF)"
+};
+
+/** Special rendering function for UAC2 clock source bmAttributes */
+static void desc_snowflake_dump_uac2_clk_src_bmattr(
+		unsigned long long value,
+		unsigned int indent)
+{
+	printf(" %s clock %s\n",
+			uac2_clk_src_bmattr[value & 0x3],
+			(value & 0x4) ? uac3_clk_src_bmattr[3] : "");
+}
+
+/** UAC2: 4.7.2.1 Clock Source Descriptor; Table 4-6. */
+static const struct desc desc_audio_2_ac_clock_source[] = {
+	{ .field = "bClockID",       .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bmAttributes",   .size = 1, .type = DESC_SNOWFLAKE,
+			.snowflake = desc_snowflake_dump_uac2_clk_src_bmattr },
+	{ .field = "bmControls",     .size = 1, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_clock_source_bmcontrols },
+	{ .field = "bAssocTerminal", .size = 1, .type = DESC_CONSTANT },
+	{ .field = "iClockSource",   .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_clock_source[3] = {
+	NULL, /* UAC1 not supported */
+	desc_audio_2_ac_clock_source,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC2: 4.7.2.2 Clock Selector Descriptor; Table 4-7. */
+static const struct desc desc_audio_2_ac_clock_selector[] = {
+	{ .field = "bClockID",       .size = 1, .type = DESC_NUMBER },
+	{ .field = "bNrInPins",      .size = 1, .type = DESC_NUMBER },
+	{ .field = "baCSourceID",    .size = 1, .type = DESC_NUMBER,
+			.array = { .array = true, .length_field1 = "bNrInPins" } },
+	{ .field = "bmControls",     .size = 1, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_clock_selector_bmcontrols },
+	{ .field = "iClockSelector", .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_clock_selector[3] = {
+	NULL, /* UAC1 not supported */
+	desc_audio_2_ac_clock_selector,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC2: 4.7.2.3 Clock Multiplier Descriptor; Table 4-8. */
+static const struct desc desc_audio_2_ac_clock_multiplier[] = {
+	{ .field = "bClockID",         .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bCSourceID",       .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",       .size = 1, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_clock_multiplier_bmcontrols },
+	{ .field = "iClockMultiplier", .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_clock_multiplier[3] = {
+	NULL, /* UAC1 not supported */
+	desc_audio_2_ac_clock_multiplier,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+/** UAC2: 4.7.2.9 Sampling Rate Converter Descriptor; Table 4-14. */
+static const struct desc desc_audio_2_ac_sample_rate_converter[] = {
+	{ .field = "bUnitID",       .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bSourceID",     .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bCSourceInID",  .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bCSourceOutID", .size = 1, .type = DESC_CONSTANT },
+	{ .field = "iSRC",          .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_ac_sample_rate_converter[3] = {
+	NULL, /* UAC1 not supported */
+	desc_audio_2_ac_sample_rate_converter,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+static const char * const uac2_as_interface_bmcontrols[] = {
+	"Active Alternate Setting",
+	"Valid Alternate Setting",
+	NULL
+};
+static const char * const audio_data_format_type_i[] = {
+	"TYPE_I_UNDEFINED",
+	"PCM",
+	"PCM8",
+	"IEEE_FLOAT",
+	"ALAW",
+	"MULAW"
+};
+static const char * const audio_data_format_type_ii[] = {
+	"TYPE_II_UNDEFINED",
+	"MPEG",
+	"AC-3"
+};
+static const char * const audio_data_format_type_iii[] = {
+	"TYPE_III_UNDEFINED",
+	"IEC1937_AC-3",
+	"IEC1937_MPEG-1_Layer1",
+	"IEC1937_MPEG-Layer2/3/NOEXT",
+	"IEC1937_MPEG-2_EXT",
+	"IEC1937_MPEG-2_Layer1_LS",
+	"IEC1937_MPEG-2_Layer2/3_LS"
+};
+
+/** Special rendering function for UAC1 AS interface wFormatTag */
+static void desc_snowflake_dump_uac1_as_interface_wformattag(
+		unsigned long long value,
+		unsigned int indent)
+{
+	const char *format_string = "undefined";
+
+	if (value <= 5) {
+		format_string = audio_data_format_type_i[value];
+
+	} else if (value >= 0x1000 && value <= 0x1002) {
+		format_string = audio_data_format_type_ii[value & 0xfff];
+
+	} else if (value >= 0x2000 && value <= 0x2006) {
+		format_string = audio_data_format_type_iii[value & 0xfff];
+	}
+
+	printf(" %s\n", format_string);
+}
+
+/** Special rendering function for UAC2 AS interface bmFormats */
+static void desc_snowflake_dump_uac2_as_interface_bmformats(
+		unsigned long long value,
+		unsigned int indent)
+{
+	unsigned int i;
+
+	printf("\n");
+	for (i = 0; i < 5; i++) {
+		if ((value >> i) & 0x1) {
+			printf("%*s%s\n", indent * 2, "",
+					audio_data_format_type_i[i + 1]);
+		}
+	}
+
+}
+
+/** UAC1: 4.5.2 Class-Specific AS Interface Descriptor; Table 4-19. */
+static const struct desc desc_audio_1_as_interface[] = {
+	{ .field = "bTerminalLink", .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bDelay",        .size = 1, .type = DESC_NUMBER_POSTFIX,
+			.number_postfix = " frames" },
+	{ .field = "wFormatTag",    .size = 2, .type = DESC_SNOWFLAKE,
+			.snowflake = desc_snowflake_dump_uac1_as_interface_wformattag },
+	{ .field = NULL }
+};
+/** UAC2: 4.9.2 Class-Specific AS Interface Descriptor; Table 4-27. */
+static const struct desc desc_audio_2_as_interface[] = {
+	{ .field = "bTerminalLink",   .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmControls",      .size = 1, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_as_interface_bmcontrols },
+	{ .field = "bFormatType",     .size = 1, .type = DESC_CONSTANT },
+	{ .field = "bmFormats",       .size = 4, .type = DESC_SNOWFLAKE,
+			.snowflake = desc_snowflake_dump_uac2_as_interface_bmformats },
+	{ .field = "bNrChannels",     .size = 1, .type = DESC_NUMBER },
+	{ .field = "bmChannelConfig", .size = 4, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac2_channel_names, .count = 26 } },
+	{ .field = "iChannelNames",   .size = 1, .type = DESC_STR_DESC_INDEX },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_as_interface[3] = {
+	desc_audio_1_as_interface,
+	desc_audio_2_as_interface,
+	NULL, /* UAC3 not implemented yet */
+};
+
+
+static const char * const uac1_as_endpoint_bmattributes[] = {
+	[0] = "Sampling Frequency",
+	[1] = "Pitch",
+	[2] = "Audio Data Format Control",
+	[7] = "MaxPacketsOnly"
+};
+static const char * const uac2_as_endpoint_bmattributes[] = {
+	[7] = "MaxPacketsOnly",
+};
+static const char * const uac2_as_isochronous_audio_data_endpoint_bmcontrols[] = {
+	"Pitch",
+	"Data Overrun",
+	"Data Underrun",
+	NULL
+};
+static const char * const uac_as_isochronous_audio_data_endpoint_blockdelayunits[] = {
+	"Undefined",
+	"Milliseconds",
+	"Decoded PCM samples",
+	NULL
+};
+
+/** UAC1: 4.6.1.2 Class-Specific AS Isochronous Audio Data Endpoint Descriptor; Table 4-21. */
+static const struct desc desc_audio_1_as_isochronous_audio_data_endpoint[] = {
+	{ .field = "bmAttributes",    .size = 1, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac1_as_endpoint_bmattributes, .count = 8 } },
+	{ .field = "bLockDelayUnits", .size = 1, .type = DESC_NUMBER_STRINGS,
+			.number_strings = uac_as_isochronous_audio_data_endpoint_blockdelayunits },
+	{ .field = "wLockDelay",      .size = 2, .type = DESC_NUMBER },
+	{ .field = NULL }
+};
+/** UAC2: 4.10.1.2 Class-Specific AS Isochronous Audio Data Endpoint Descriptor; Table 4-34. */
+static const struct desc desc_audio_2_as_isochronous_audio_data_endpoint[] = {
+	{ .field = "bmAttributes",    .size = 1, .type = DESC_BITMAP_STRINGS,
+			.bitmap_strings = { .strings = uac2_as_endpoint_bmattributes, .count = 8 } },
+	{ .field = "bmControls",      .size = 1, .type = DESC_BMCONTROL_2,
+			.bmcontrol = uac2_as_isochronous_audio_data_endpoint_bmcontrols },
+	{ .field = "bLockDelayUnits", .size = 1, .type = DESC_NUMBER_STRINGS,
+			.number_strings = uac_as_isochronous_audio_data_endpoint_blockdelayunits },
+	{ .field = "wLockDelay",      .size = 2, .type = DESC_NUMBER },
+	{ .field = NULL }
+};
+const struct desc * const desc_audio_as_isochronous_audio_data_endpoint[3] = {
+	desc_audio_1_as_isochronous_audio_data_endpoint,
+	desc_audio_2_as_isochronous_audio_data_endpoint,
+	NULL, /* UAC3 not implemented yet */
+};

--- a/desc-defs.h
+++ b/desc-defs.h
@@ -1,0 +1,153 @@
+/*****************************************************************************/
+
+/*
+ *      desc-defs.h  --  USB descriptor definitions
+ *
+ *      Copyright (C) 2017 Michael Drake <michael.drake@codethink.co.uk>
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ */
+
+/*****************************************************************************/
+
+#ifndef _DESC_DEFS_H
+#define _DESC_DEFS_H
+
+/* ---------------------------------------------------------------------- */
+
+/**
+ * Descriptor field value type.
+ *
+ * Note that there are more types here than exist in the descriptor definitions
+ * in the specifications.  This is because the type here is used to do `lsusb`
+ * specific rendering of certain fields.
+ *
+ * Note that the use of certain types mandates the setting of various entries
+ * in the type-specific anonymous union in `struct desc`.
+ */
+enum desc_type {
+	DESC_CONSTANT,       /** Plain numerical value; no annotation. */
+	DESC_NUMBER,         /** Plain numerical value; no annotation. */
+	DESC_NUMBER_POSTFIX, /**< Number with a postfix string. */
+	DESC_BITMAP,         /**< Plain hex rendered value; no annotation. */
+	DESC_BCD,            /**< Binary coded decimal */
+	DESC_BMCONTROL_1,    /**< UAC1 style bmControl field */
+	DESC_BMCONTROL_2,    /**< UAC2/UAC3 style bmControl field */
+	DESC_STR_DESC_INDEX, /**< String index. */
+	DESC_TERMINAL_STR,   /**< Audio terminal string. */
+	DESC_BITMAP_STRINGS, /**< Bitfield with string per bit. */
+	DESC_NUMBER_STRINGS, /**< Use for enum-style value to string. */
+	DESC_SNOWFLAKE,  /**< Value with custom annotation callback function. */
+};
+
+/**
+ * Callback function for the DESC_SNOWFLAKE descriptor field value type.
+ *
+ * This is used when some special rendering of the value is required, which
+ * is specific to the field in question, so no generic type's rendering is
+ * suitable.
+ *
+ * The core descriptor dumping code will have already dumped the numerical
+ * value for the field, but not the trailing newline character.  It is up
+ * to the callback function to ensure it always finishes by writing a '\n'
+ * character to stdout.
+ *
+ * \param[in] value    The value to dump a human-readable representation of.
+ * \param[in] indent   The current indent level.
+ */
+typedef void (*desc_snowflake_dump_fn)(
+		unsigned long long value,
+		unsigned int indent);
+
+
+/**
+ * Descriptor field definition.
+ *
+ * Whole descriptors can be defined as NULL terminated arrays of these
+ * structures.
+ */
+struct desc {
+	const char *field;   /**< Field's name */
+	unsigned int size;   /**< Byte size of field, if (size_field == NULL) */
+	const char *size_field; /**< Name of field specifying field size. */
+	enum desc_type type; /**< Field's value type. */
+
+	/** Anonymous union containing type-specific data. */
+	union {
+		/**
+		 * Corresponds to types DESC_BMCONTROL_1 and DESC_BMCONTROL_2.
+		 *
+		 * Must be a NULL terminated array of '\0' terminated strings.
+		 */
+		const char * const *bmcontrol;
+		/** Corresponds to type DESC_BITMAP_STRINGS */
+		struct {
+			/** Must contain '\0' terminated strings. */
+			const char * const *strings;
+			/** Number of strings in strings array. */
+			unsigned int count;
+		} bitmap_strings;
+		/**
+		 * Corresponds to type DESC_NUMBER_STRINGS.
+		 *
+		 * Must be a NULL terminated array of '\0' terminated strings.
+		 */
+		const char * const *number_strings;
+		/**
+		 * Corresponds to type DESC_NUMBER_POSTFIX.
+		 *
+		 * Must be a '\0' terminated string.
+		 */
+		const char *number_postfix;
+		/**
+		 * Corresponds to type DESC_SNOWFLAKE.
+		 *
+		 * Callback function called to annotate snowflake value type.
+		 */
+		desc_snowflake_dump_fn snowflake;
+	};
+
+	/** Grouping of array-specific fields. */
+	struct {
+		bool array; /**< True if entry is an array. */
+		bool bits;  /**< True if array length is specified in bits */
+		/** Name of field specifying the array entry count. */
+		const char *length_field1;
+		/** Name of field specifying multiplier for array entry count. */
+		const char *length_field2;
+	} array;
+};
+
+/* ---------------------------------------------------------------------- */
+
+/* Audio Control (AC) descriptor definitions */
+extern const struct desc * const desc_audio_ac_header[3];
+extern const struct desc * const desc_audio_ac_effect_unit[3];
+extern const struct desc * const desc_audio_ac_input_terminal[3];
+extern const struct desc * const desc_audio_ac_output_terminal[3];
+extern const struct desc * const desc_audio_ac_mixer_unit[3];
+extern const struct desc * const desc_audio_ac_selector_unit[3];
+extern const struct desc * const desc_audio_ac_processing_unit[3];
+extern const struct desc * const desc_audio_ac_feature_unit[3];
+extern const struct desc * const desc_audio_ac_extension_unit[3];
+extern const struct desc * const desc_audio_ac_clock_source[3];
+extern const struct desc * const desc_audio_ac_clock_selector[3];
+extern const struct desc * const desc_audio_ac_clock_multiplier[3];
+extern const struct desc * const desc_audio_ac_sample_rate_converter[3];
+
+/* Audio Streaming (AS) descriptor definitions */
+extern const struct desc * const desc_audio_as_interface[3];
+extern const struct desc * const desc_audio_as_isochronous_audio_data_endpoint[3];
+
+/* ---------------------------------------------------------------------- */
+
+#endif /* _DESC_DEFS_H */

--- a/desc-defs.h
+++ b/desc-defs.h
@@ -43,6 +43,7 @@ enum desc_type {
 	DESC_BMCONTROL_1,    /**< UAC1 style bmControl field */
 	DESC_BMCONTROL_2,    /**< UAC2/UAC3 style bmControl field */
 	DESC_STR_DESC_INDEX, /**< String index. */
+	DESC_CS_STR_DESC_ID, /**< UAC3 style class-specific string request. */
 	DESC_TERMINAL_STR,   /**< Audio terminal string. */
 	DESC_BITMAP_STRINGS, /**< Bitfield with string per bit. */
 	DESC_NUMBER_STRINGS, /**< Use for enum-style value to string. */
@@ -134,6 +135,8 @@ extern const struct desc * const desc_audio_ac_header[3];
 extern const struct desc * const desc_audio_ac_effect_unit[3];
 extern const struct desc * const desc_audio_ac_input_terminal[3];
 extern const struct desc * const desc_audio_ac_output_terminal[3];
+extern const struct desc * const desc_audio_ac_extended_terminal[3];
+extern const struct desc * const desc_audio_ac_power_domain[3];
 extern const struct desc * const desc_audio_ac_mixer_unit[3];
 extern const struct desc * const desc_audio_ac_selector_unit[3];
 extern const struct desc * const desc_audio_ac_processing_unit[3];

--- a/desc-defs.h
+++ b/desc-defs.h
@@ -151,6 +151,9 @@ extern const struct desc * const desc_audio_ac_sample_rate_converter[3];
 extern const struct desc * const desc_audio_as_interface[3];
 extern const struct desc * const desc_audio_as_isochronous_audio_data_endpoint[3];
 
+/* Device Capability (DC) descriptor definitions */
+extern const struct desc desc_usb3_dc_configuration_summary[];
+
 /* ---------------------------------------------------------------------- */
 
 #endif /* _DESC_DEFS_H */

--- a/desc-dump.c
+++ b/desc-dump.c
@@ -272,6 +272,11 @@ static void value_renderer(
 		}
 		break;
 	}
+	case DESC_CS_STR_DESC_ID:
+		number_renderer(buf, size_chars, offset, current_size);
+		/* TODO: Add support for UAC3 class-specific String descriptor */
+		printf("\n");
+		break;
 	case DESC_TERMINAL_STR:
 		number_renderer(buf, size_chars, offset, current_size);
 		printf(" %s\n", names_audioterminal(

--- a/desc-dump.c
+++ b/desc-dump.c
@@ -1,0 +1,550 @@
+/*****************************************************************************/
+
+/*
+ *      desc-dump.c  --  USB descriptor dumping
+ *
+ *      Copyright (C) 2017 Michael Drake <michael.drake@codethink.co.uk>
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ */
+
+/*****************************************************************************/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <libusb.h>
+
+#include "desc-defs.h"
+#include "desc-dump.h"
+#include "usbmisc.h"
+#include "names.h"
+
+
+/**
+ * Print a description of a bmControls field value, using a given string array.
+ *
+ * Handles the DESC_BMCONTROL_1 and DESC_BMCONTROL_2 field types.  The former
+ * is one bit per string, and the latter is 2 bits per string, with the
+ * additional bit specifying whether the control is read-only.
+ *
+ * \param[in] bmcontrols  The value to dump a human-readable representation of.
+ * \param[in] strings     Array of human-readable strings, must be NULL terminated.
+ * \param[in] type        The type of the value in bmcontrols.
+ * \param[in] indent      The current indent level.
+ */
+static void desc_bmcontrol_dump(
+		unsigned long long bmcontrols,
+		const char * const * strings,
+		enum desc_type type,
+		unsigned int indent)
+{
+	static const char * const setting[] = {
+		"read-only",
+		"ILLEGAL VALUE (0b10)",
+		"read/write"
+	};
+	unsigned int count = 0;
+	unsigned int control;
+
+	assert((type == DESC_BMCONTROL_1) ||
+	       (type == DESC_BMCONTROL_2));
+
+	while (strings[count] != NULL) {
+		if (strings[0] != '\0') {
+			if (type == DESC_BMCONTROL_1) {
+				if ((strings[count][0] != '\0') &&
+				    (bmcontrols >> count) & 0x1) {
+					printf("%*s%s Control\n",
+							indent * 2, "",
+							strings[count]);
+				}
+			} else {
+				control = (bmcontrols >> (count * 2)) & 0x3;
+				if ((strings[count][0] != '\0') && control) {
+					printf("%*s%s Control (%s)\n",
+							indent * 2, "",
+							strings[count],
+							setting[control-1]);
+				}
+			}
+		}
+		count++;
+	}
+}
+
+
+/**
+ * Read N bytes from descriptor data buffer into a value.
+ *
+ * Only supports values of up to 8 bytes.
+ *
+ * \param[in] buf     Buffer containing the bytes to read.
+ * \param[in] offset  Offset in buffer to start reading bytes from.
+ * \param[in] bytes   Number of bytes to read.
+ * \return Value contained within the given bytes.
+ */
+static unsigned long long get_n_bytes_as_ull(
+		const unsigned char *buf,
+		unsigned int offset,
+		unsigned int bytes)
+{
+	unsigned long long ret = 0;
+
+	if (bytes > 8) {
+		fprintf(stderr, "Bad descriptor definition; Field size > 8.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	buf += offset;
+
+	switch (bytes) {
+	case 8: ret |= ((unsigned long long)buf[7]) << 56; /* fall-through */
+	case 7: ret |= ((unsigned long long)buf[6]) << 48; /* fall-through */
+	case 6: ret |= ((unsigned long long)buf[5]) << 40; /* fall-through */
+	case 5: ret |= ((unsigned long long)buf[4]) << 32; /* fall-through */
+	case 4: ret |= ((unsigned long long)buf[3]) << 24; /* fall-through */
+	case 3: ret |= ((unsigned long long)buf[2]) << 16; /* fall-through */
+	case 2: ret |= ((unsigned long long)buf[1]) <<  8; /* fall-through */
+	case 1: ret |= ((unsigned long long)buf[0]);
+	}
+
+	return ret;
+}
+
+/**
+ * Dump a number as hex to stdout.
+ *
+ * \param[in] buf     Descriptor buffer to get values to render from.
+ * \param[in] width   Character width to right-align value inside.
+ * \param[in] offset  Offset in buffer to start of value to render.
+ * \param[in] bytes   Byte length of value to render.
+ */
+static void hex_renderer(
+		const unsigned char *buf,
+		unsigned int width,
+		unsigned int offset,
+		unsigned int bytes)
+{
+	unsigned int align = (width >= bytes * 2) ? width - bytes * 2 : 0;
+	printf(" %*s0x%0*llx", align, "", bytes * 2,
+			get_n_bytes_as_ull(buf, offset, bytes));
+}
+
+
+/**
+ * Dump a number to stdout.
+ *
+ * Single-byte numbers a rendered as decimal, otherwise hexadecimal is used.
+ *
+ * \param[in] buf     Descriptor buffer to get values to render from.
+ * \param[in] width   Character width to right-align value inside.
+ * \param[in] offset  Offset in buffer to start of value to render.
+ * \param[in] bytes   Byte length of value to render.
+ */
+static void number_renderer(
+		const unsigned char *buf,
+		unsigned int width,
+		unsigned int offset,
+		unsigned int bytes)
+{
+	if (bytes == 1) {
+		/* Render small numbers as decimal */
+		printf("   %*u", width, buf[offset]);
+	} else {
+		/* Otherwise render as hexadecimal */
+		hex_renderer(buf, width, offset, bytes);
+	}
+}
+
+
+/**
+ * Render a field's value to stdout.
+ *
+ * The manner of rendering the value is dependant on the value type.
+ *
+ * \param[in] dev           LibUSB device handle.
+ * \param[in] current       Descriptor definition field to render.
+ * \param[in] current_size  Descriptor definition field to render.
+ * \param[in] buf           Byte array containing the descriptor date to dump.
+ * \param[in] indent        Current indent level.
+ * \param[in] offset        Offset to current value in `buf`.
+ */
+static void value_renderer(
+		libusb_device_handle *dev,
+		const struct desc *current,
+		unsigned int current_size,
+		const unsigned char *buf,
+		unsigned int indent,
+		size_t offset)
+{
+	/** Maximum amount of characters to right align numerical values by. */
+	const unsigned int size_chars = 4;
+
+	switch (current->type) {
+	case DESC_NUMBER: /* fall-through */
+	case DESC_CONSTANT:
+		number_renderer(buf, size_chars, offset, current_size);
+		printf("\n");
+		break;
+	case DESC_NUMBER_POSTFIX:
+		number_renderer(buf, size_chars, offset, current_size);
+		printf("%s\n", current->number_postfix);
+		break;
+	case DESC_NUMBER_STRINGS: {
+		unsigned int i;
+		unsigned long long value = get_n_bytes_as_ull(buf, offset, current_size);
+		number_renderer(buf, size_chars, offset, current_size);
+		for (i = 0; i <= value; i++) {
+			if (current->number_strings[i] == NULL) {
+				break;
+			}
+			if (value == i) {
+				printf(" %s", current->number_strings[i]);
+			}
+		}
+		printf("\n");
+		break;
+	}
+	case DESC_BCD: {
+		unsigned int i;
+		printf("  %2x", buf[offset + current_size - 1]);
+		for (i = 1; i < current_size; i++) {
+			printf(".%02x", buf[offset + current_size - 1 - i]);
+		}
+		printf("\n");
+		break;
+	}
+	case DESC_BITMAP:
+		hex_renderer(buf, size_chars, offset, current_size);
+		printf("\n");
+		break;
+	case DESC_BMCONTROL_1: /* fall-through */
+	case DESC_BMCONTROL_2:
+		hex_renderer(buf, size_chars, offset, current_size);
+		printf("\n");
+		desc_bmcontrol_dump(
+				get_n_bytes_as_ull(buf, offset, current_size),
+				current->bmcontrol, current->type, indent + 1);
+		break;
+	case DESC_BITMAP_STRINGS: {
+		unsigned int i;
+		unsigned long long value = get_n_bytes_as_ull(buf, offset, current_size);
+		hex_renderer(buf, size_chars, offset, current_size);
+		printf("\n");
+		for (i = 0; i < current->bitmap_strings.count; i++) {
+			if (current->bitmap_strings.strings[i] == NULL) {
+				continue;
+			}
+			if (((value >> i) & 0x1) == 0) {
+				continue;
+			}
+			printf("%*s%s\n", (indent + 1) * 2, "",
+					current->bitmap_strings.strings[i]);
+		}
+		break;
+	}
+	case DESC_STR_DESC_INDEX: {
+		char *string;
+		number_renderer(buf, size_chars, offset, current_size);
+		string = get_dev_string(dev, buf[offset]);
+		if (string) {
+			printf(" %s\n", string);
+			free(string);
+		} else {
+			printf("\n");
+		}
+		break;
+	}
+	case DESC_TERMINAL_STR:
+		number_renderer(buf, size_chars, offset, current_size);
+		printf(" %s\n", names_audioterminal(
+				get_n_bytes_as_ull(buf, offset, current_size)));
+		break;
+	case DESC_SNOWFLAKE:
+		number_renderer(buf, size_chars, offset, current_size);
+		current->snowflake(
+				get_n_bytes_as_ull(buf, offset, current_size),
+				indent + 1);
+		break;
+	}
+}
+
+
+/**
+ * Get the size of a descriptor field in bytes.
+ *
+ * Normally the size is provided in the entry's size parameter, but some
+ * fields have a variable size, with the actual size being stored in as
+ * the value of another field.
+ *
+ * \param[in] buf    Descriptor data.
+ * \param[in] desc   First field in the descriptor definition array.
+ * \param[in] entry  The descriptor definition field to get size for.
+ * \return Size of the field in bytes.
+ */
+static unsigned int get_entry_size(
+		const unsigned char *buf,
+		const struct desc *desc,
+		const struct desc *entry)
+{
+	const struct desc *current;
+	unsigned int size = entry->size;
+
+	if (entry->size_field != NULL) {
+		/* Variable field length, given by `size_field`'s value. */
+		size_t offset = 0;
+
+		/* Search descriptor definition array for the field who's value
+		 * gives the size of the entry we're interested in. */
+		for (current = desc; current->field != NULL; current++) {
+			if (strcmp(current->field, entry->size_field) == 0) {
+				/* Found the field who's value gives us the
+				 * size of, so read that field's value out of
+				 * the descriptor data buffer. */
+				size = get_n_bytes_as_ull(buf, offset,
+						current->size);
+				break;
+			}
+
+			/* Keep track of our offset in the descriptor data
+			 * as we look for the field we want. */
+			offset += get_entry_size(buf, desc, current);
+		}
+	}
+
+	if (size == 0) {
+		fprintf(stderr, "Bad descriptor definition; "
+				"'%s' field has zero size.\n", entry->field);
+		exit(EXIT_FAILURE);
+	}
+
+	return size;
+}
+
+
+/**
+ * Get the number of entries needed by an descriptor definition array field.
+ *
+ * The number of entries is either calculated from length_field parameters,
+ * which indicate which other field(s) contain values representing the
+ * array length, or the array length is calculated from the buf_len parameter,
+ * which should ultimately have been derived from the bLength field in the raw
+ * descriptor data.
+ *
+ * \param[in] buf          Descriptor data.
+ * \param[in] buf_len      Byte length of `buf`.
+ * \param[in] desc         First field in the descriptor definition.
+ * \param[in] array_entry  Array field to get entry count for.
+ * \return Number of entries in array.
+ */
+static unsigned int get_array_entry_count(
+		const unsigned char *buf,
+		unsigned int buf_len,
+		const struct desc *desc,
+		const struct desc *array_entry)
+{
+	const struct desc *current;
+	unsigned int entries = 0;
+
+	if (array_entry->array.length_field1) {
+		/* We can get the array size from the length_field1. */
+		size_t offset = 0;
+		for (current = desc; current->field != NULL; current++) {
+			if (strcmp(current->field, array_entry->array.length_field1) == 0) {
+				entries = get_n_bytes_as_ull(buf, offset, current->size);
+				break;
+			}
+
+			offset += get_entry_size(buf, desc, current);
+		}
+		offset = 0; /* skip first three common 1-byte fields */
+		if (array_entry->array.length_field2 != NULL) {
+			/* There's a second field specifying length.  The two
+			 * lengths are multiplied. */
+			for (current = desc; current->field != NULL; current++) {
+				if (strcmp(current->field, array_entry->array.length_field2) == 0) {
+					entries *= get_n_bytes_as_ull(buf, offset, current->size);
+					break;
+				}
+
+				offset += get_entry_size(buf, desc, current);
+			}
+		}
+
+		/* If the bits flag is set, then the entry count so far
+		 * was a bit count, and we need to get a byte count. */
+		if (array_entry->array.bits) {
+			entries = (entries / 8) + (entries & 0x7) ? 1 : 0;
+		}
+	} else {
+		/* Inferred array length.  We haven't been given a field to get
+		 * length from; start with the descriptor's byte-length, and
+		 * subtract the sizes of all the other fields. */
+		unsigned int size = buf_len;
+
+		for (current = desc; current->field != NULL; current++) {
+			if (current == array_entry)
+				continue;
+
+			if (current->array.array) {
+				unsigned int count;
+				/* We can't deal with two inferred-length arrays
+				 * in one descriptor definition, because its
+				 * an unresolvable ambiguity.  If this
+				 * happens it's a flaw in the descriptor
+				 * definition. */
+				if (current->array.length_field1 == NULL) {
+					return 0xffffffff;
+				}
+				count = get_array_entry_count(buf, buf_len,
+						desc, current);
+				if (count == 0xffffffff) {
+					fprintf(stderr, "Bad descriptor definition; "
+						"multiple inferred-length arrays.\n");
+					exit(EXIT_FAILURE);
+				}
+				size -= get_entry_size(buf, desc, current) *
+						count;
+			} else {
+				size -= get_entry_size(buf, desc, current);
+			}
+		}
+
+		entries = size / array_entry->size;
+	}
+
+	return entries;
+}
+
+
+/**
+ * Get the number of characters needed to dump an array index
+ *
+ * \param[in] array_entries  Number of entries in array.
+ * \return number of characters required to render largest possible index.
+ */
+static unsigned int get_char_count_for_array_index(unsigned int array_entries)
+{
+	/* Arrays are zero-indexed, so largest index is array_entries - 1. */
+	if (array_entries > 100) {
+		/* [NNN] */
+		return 5;
+	} else if (array_entries > 10) {
+		/* [NN] */
+		return 4;
+	}
+
+	/* [N] */
+	return 3;
+}
+
+/* Function documented in desc-dump.h */
+void desc_dump(
+		libusb_device_handle *dev,
+		const struct desc *desc,
+		const unsigned char *buf,
+		unsigned int buf_len,
+		unsigned int indent)
+{
+	unsigned int entry;
+	unsigned int entries;
+	unsigned int needed_chars;
+	unsigned int current_size;
+	unsigned int field_len = 18;
+	const struct desc *current;
+	size_t offset = 0;
+
+	/* Find the buffer length, if we've been instructed to read it from
+	 * the first field. */
+	if ((buf_len == DESC_BUF_LEN_FROM_BUF) && (desc != NULL)) {
+		buf_len = get_n_bytes_as_ull(buf, offset, desc->size);
+	}
+
+	/* Increase `field_len` to be sufficient for character length of
+	 * longest field name for this descriptor. */
+	for (current = desc; current->field != NULL; current++) {
+		needed_chars = 0;
+		if (current->array.array) {
+			entries = get_array_entry_count(buf, buf_len,
+					desc, current);
+			needed_chars = get_char_count_for_array_index(entries);
+		}
+		if (strlen(current->field) + needed_chars > field_len) {
+			field_len = strlen(current->field) + needed_chars;
+		}
+	}
+
+	/* Step through each field, and dump it. */
+	for (current = desc; current->field != NULL; current++) {
+		entries = 1;
+		if (current->array.array) {
+			/* Array type fields may have more than one entry. */
+			entries = get_array_entry_count(buf, buf_len,
+					desc, current);
+		}
+
+		current_size = get_entry_size(buf, desc, current);
+
+		for (entry = 0; entry < entries; entry++) {
+			/* Check there's enough data in buf for this entry. */
+			if (offset + current_size > buf_len) {
+				unsigned int i;
+				printf("%*sWarning: Length insufficient for "
+						"descriptor type.\n",
+						(indent - 1) * 2, "");
+				for (i = offset; i < buf_len; i++) {
+					printf("%02x ", buf[i]);
+				}
+				printf("\n");
+				return;
+			}
+			/* Dump the field name */
+			if (current->array.array) {
+				needed_chars = field_len -
+						get_char_count_for_array_index(
+								entries) -
+						strlen(current->field);
+				printf("%*s%s(%u)%*s", indent * 2, "",
+						current->field, entry,
+						needed_chars, "");
+			} else {
+				printf("%*s%-*s", indent * 2, "",
+						field_len, current->field);
+			}
+			/* Dump the value */
+			value_renderer(dev, current, current_size, buf,
+					indent, offset);
+			/* Advance offset in buffer */
+			offset += current_size;
+		}
+	}
+
+	/* Check for junk at end of descriptor. */
+	if (offset < buf_len) {
+		unsigned int i;
+		printf("%*sWarning: Junk at end of descriptor (%zu bytes):\n",
+				(indent - 1) * 2, "", buf_len - offset);
+		printf("%*s", indent * 2, "");
+		for (i = offset; i < buf_len; i++) {
+			printf("%02x ", buf[i]);
+		}
+		printf("\n");
+	}
+}

--- a/desc-dump.h
+++ b/desc-dump.h
@@ -1,0 +1,64 @@
+/*****************************************************************************/
+
+/*
+ *      desc-dump.h  --  USB descriptor dumping
+ *
+ *      Copyright (C) 2017 Michael Drake <michael.drake@codethink.co.uk>
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ */
+
+/*****************************************************************************/
+
+#ifndef _DESC_DUMP_H
+#define _DESC_DUMP_H
+
+/* ---------------------------------------------------------------------- */
+
+/**
+ * Buffer length value indicating that the buffer length should be
+ * read from the value of the first field in the buffer, as defined
+ * by the first field descriptor definition.
+ */
+#define DESC_BUF_LEN_FROM_BUF 0xffffffff
+
+/**
+ * Dump descriptor using a descriptor definition array.
+ *
+ * This function dumps the USB descriptor data given in the byte array,
+ * `buf`, according to the descriptor definition array given in `desc`.
+ *
+ * The first byte(s) of `buf` must correspond to the first field definition
+ * in the `desc` descriptor definition array.
+ *
+ * \param[in] dev     LibUSB device handle.
+ * \param[in] desc    Array of descriptor field definitions to use to interpret
+ *                    `buf`.  This array constitutes the descriptor definition.
+ *                    The final entry in the array must have a NULL field name,
+ *                    which is interpreted as the end of the array.
+ * \param[in] buf     Byte array containing the descriptor data to dump.
+ * \param[in] buf_len Byte length of `buf` or `DESC_BUF_LEN_FROM_BUF` to get
+ *                    the length from the value of the first field in the
+ *                    descriptor data.
+ * \param[in] indent  Indent level to use for descriptor dump.
+ */
+extern void desc_dump(
+		libusb_device_handle *dev,
+		const struct desc *desc,
+		const unsigned char *buf,
+		unsigned int buf_len,
+		unsigned int indent);
+
+
+/* ---------------------------------------------------------------------- */
+
+#endif /* _DESC_DUMP_H */

--- a/lsusb.c
+++ b/lsusb.c
@@ -75,6 +75,7 @@
 #define USB_DC_PLATFORM 		0x05
 #define USB_DC_SUPERSPEEDPLUS		0x0a
 #define USB_DC_BILLBOARD		0x0d
+#define USB_DC_CONFIGURATION_SUMMARY	0x10
 
 /* Conventional codes for class-specific descriptors.  The convention is
  * defined in the USB "Common Class" Spec (3.11).  Individual class specs
@@ -3512,6 +3513,11 @@ static void dump_bos_descriptor(libusb_device_handle *fd)
 			break;
 		case USB_DC_BILLBOARD:
 			dump_billboard_device_capability_desc(fd, buf);
+			break;
+		case USB_DC_CONFIGURATION_SUMMARY:
+			printf("  Configuration Summary Device Capability:\n");
+			desc_dump(fd, desc_usb3_dc_configuration_summary,
+					buf, DESC_BUF_LEN_FROM_BUF, 2);
 			break;
 		default:
 			printf("  ** UNRECOGNIZED: ");

--- a/lsusb.c
+++ b/lsusb.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #ifdef HAVE_BYTESWAP_H
 #include <byteswap.h>
@@ -42,6 +43,8 @@
 #include "lsusb.h"
 #include "names.h"
 #include "usbmisc.h"
+#include "desc-defs.h"
+#include "desc-dump.h"
 
 #include <getopt.h>
 
@@ -159,7 +162,7 @@ static void dump_videostreaming_interface(const unsigned char *buf);
 static void dump_dfu_interface(const unsigned char *buf);
 static char *dump_comm_descriptor(libusb_device_handle *dev, const unsigned char *buf, char *indent);
 static void dump_hid_device(libusb_device_handle *dev, const struct libusb_interface_descriptor *interface, const unsigned char *buf);
-static void dump_audiostreaming_endpoint(const unsigned char *buf, int protocol);
+static void dump_audiostreaming_endpoint(libusb_device_handle *dev, const unsigned char *buf, int protocol);
 static void dump_midistreaming_endpoint(const unsigned char *buf);
 static void dump_hub(const char *prefix, const unsigned char *p, int tt_type);
 static void dump_ccid_device(const unsigned char *buf);
@@ -626,7 +629,7 @@ static void dump_altsetting(libusb_device_handle *dev, const struct libusb_inter
 					case USB_DT_CS_ENDPOINT:
 						switch (interface->bInterfaceSubClass) {
 						case 2:
-							dump_audiostreaming_endpoint(buf, interface->bInterfaceProtocol);
+							dump_audiostreaming_endpoint(dev, buf, interface->bInterfaceProtocol);
 							break;
 						default:
 							goto dump;
@@ -756,7 +759,7 @@ static void dump_endpoint(libusb_device_handle *dev, const struct libusb_interfa
 			switch (buf[1]) {
 			case USB_DT_CS_ENDPOINT:
 				if (interface->bInterfaceClass == 1 && interface->bInterfaceSubClass == 2)
-					dump_audiostreaming_endpoint(buf, interface->bInterfaceProtocol);
+					dump_audiostreaming_endpoint(dev, buf, interface->bInterfaceProtocol);
 				else if (interface->bInterfaceClass == 1 && interface->bInterfaceSubClass == 3)
 					dump_midistreaming_endpoint(buf);
 				break;
@@ -880,125 +883,32 @@ static void dump_unit(unsigned int data, unsigned int len)
  * Audio Class descriptor dump
  */
 
-struct bmcontrol {
-	const char *name;
-	unsigned int bit;
-};
-
-static const struct bmcontrol uac2_interface_header_bmcontrols[] = {
-	{ "Latency control",	0 },
-	{ NULL }
-};
-
-static const struct bmcontrol uac_fu_bmcontrols[] = {
-	{ "Mute",		0 },
-	{ "Volume",		1 },
-	{ "Bass",		2 },
-	{ "Mid",		3 },
-	{ "Treble",		4 },
-	{ "Graphic Equalizer",	5 },
-	{ "Automatic Gain",	6 },
-	{ "Delay",		7 },
-	{ "Bass Boost",		8 },
-	{ "Loudness",		9 },
-	{ "Input gain",		10 },
-	{ "Input gain pad",	11 },
-	{ "Phase inverter",	12 },
-	{ NULL }
-};
-
-static const struct bmcontrol uac2_input_term_bmcontrols[] = {
-	{ "Copy Protect",	0 },
-	{ "Connector",		1 },
-	{ "Overload",		2 },
-	{ "Cluster",		3 },
-	{ "Underflow",		4 },
-	{ "Overflow",		5 },
-	{ NULL }
-};
-
-static const struct bmcontrol uac2_output_term_bmcontrols[] = {
-	{ "Copy Protect",	0 },
-	{ "Connector",		1 },
-	{ "Overload",		2 },
-	{ "Underflow",		3 },
-	{ "Overflow",		4 },
-	{ NULL }
-};
-
-static const struct bmcontrol uac2_mixer_unit_bmcontrols[] = {
-	{ "Cluster",		0 },
-	{ "Underflow",		1 },
-	{ "Overflow",		2 },
-	{ NULL }
-};
-
-static const struct bmcontrol uac2_extension_unit_bmcontrols[] = {
-	{ "Enable",		0 },
-	{ "Cluster",		1 },
-	{ "Underflow",		2 },
-	{ "Overflow",		3 },
-	{ NULL }
-};
-
-static const struct bmcontrol uac2_clock_source_bmcontrols[] = {
-	{ "Clock Frequency",	0 },
-	{ "Clock Validity",	1 },
-	{ NULL }
-};
-
-static const struct bmcontrol uac2_clock_selector_bmcontrols[] = {
-	{ "Clock Selector",	0 },
-	{ NULL }
-};
-
-static const struct bmcontrol uac2_clock_multiplier_bmcontrols[] = {
-	{ "Clock Numerator",	0 },
-	{ "Clock Denominator",	1 },
-	{ NULL }
-};
-
-static const struct bmcontrol uac2_selector_bmcontrols[] = {
-	{ "Selector",	0 },
-	{ NULL }
-};
-
-static void dump_audio_bmcontrols(const char *prefix, int bmcontrols, const struct bmcontrol *list, int protocol)
+static void dump_audio_subtype(libusb_device_handle *dev,
+                               const char *name,
+                               const struct desc * const desc[3],
+                               const unsigned char *buf,
+                               int protocol,
+                               unsigned int indent)
 {
-	while (list->name) {
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			if (bmcontrols & (1 << list->bit))
-				printf("%s%s Control\n", prefix, list->name);
+	static const char * const strings[] = { "UAC1", "UAC2" };
+	unsigned int idx = 0;
 
-			break;
-
-		case USB_AUDIO_CLASS_2: {
-			const char * const ctrl_type[] = { "read-only", "ILLEGAL (0b10)", "read/write" };
-			int ctrl = (bmcontrols >> (list->bit * 2)) & 0x3;
-
-			if (ctrl)
-				printf("%s%s Control (%s)\n", prefix, list->name, ctrl_type[ctrl-1]);
-
-			break;
-		}
-
-		} /* switch */
-
-		list++;
+	switch (protocol) {
+	case USB_AUDIO_CLASS_2: idx = 1; break;
 	}
-}
 
-static const char * const chconfig_uac2[] = {
-	"Front Left (FL)", "Front Right (FR)", "Front Center (FC)", "Low Frequency Effects (LFE)",
-	"Back Left (BL)", "Back Right (BR)", "Front Left of Center (FLC)", "Front Right of Center (FRC)", "Back Center (BC)",
-	"Side Left (SL)", "Side Right (SR)",
-	"Top Center (TC)", "Top Front Left (TFL)", "Top Front Center (TFC)", "Top Front Right (TFR)", "Top Back Left (TBL)",
-	"Top Back Center (TBC)", "Top Back Right (TBR)", "Top Front Left of Center (TFLC)", "Top Front Right of Center (TFRC)",
-	"Left Low Frequency Effects (LLFE)", "Right Low Frequency Effects (RLFE)",
-	"Top Side Left (TSL)", "Top Side Right (TSR)", "Bottom Center (BC)",
-	"Back Left of Center (BLC)", "Back Right of Center (BRC)"
-};
+	printf("(%s)\n", name);
+
+	if (desc[idx] == NULL) {
+		printf("%*sWarning: %s descriptors are illegal for %s\n",
+		       indent * 2, "", name, strings[idx]);
+		return;
+	}
+
+	/* Skip the first three bytes; those common fields have already
+	 * been dumped. */
+	desc_dump(dev, desc[idx], buf + 3, buf[0] - 3, indent);
+}
 
 /* USB Audio Class subtypes */
 enum uac_interface_subtype {
@@ -1074,21 +984,9 @@ static enum uac_interface_subtype get_uac_interface_subtype(unsigned char c, int
 	return c;
 }
 
-
-
 static void dump_audiocontrol_interface(libusb_device_handle *dev, const unsigned char *buf, int protocol)
 {
 	enum uac_interface_subtype subtype;
-	static const char * const chconfig[] = {
-		"Left Front (L)", "Right Front (R)", "Center Front (C)", "Low Frequency Enhancement (LFE)",
-		"Left Surround (LS)", "Right Surround (RS)", "Left of Center (LC)", "Right of Center (RC)",
-		"Surround (S)", "Side Left (SL)", "Side Right (SR)", "Top (T)"
-	};
-	static const char * const clock_source_attrs[] = {
-		"External", "Internal fixed", "Internal variable", "Internal programmable"
-	};
-	unsigned int i, chcfg, j, k, N, termt;
-	char *chnames = NULL, *term = NULL, termts[128];
 
 	if (buf[1] != USB_DT_CS_INTERFACE)
 		printf("      Warning: Invalid descriptor\n");
@@ -1103,515 +1001,56 @@ static void dump_audiocontrol_interface(libusb_device_handle *dev, const unsigne
 	subtype = get_uac_interface_subtype(buf[2], protocol);
 
 	switch (subtype) {
-	case 0x01:  /* HEADER */
-		printf("(HEADER)\n");
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			if (buf[0] < 8+buf[7])
-				printf("      Warning: Descriptor too short\n");
-			printf("        bcdADC              %2x.%02x\n"
-			       "        wTotalLength        %5u\n"
-			       "        bInCollection       %5u\n",
-			       buf[4], buf[3], buf[5] | (buf[6] << 8), buf[7]);
-			for (i = 0; i < buf[7]; i++)
-				printf("        baInterfaceNr(%2u)   %5u\n", i, buf[8+i]);
-			dump_junk(buf, "        ", 8+buf[7]);
-			break;
-		case USB_AUDIO_CLASS_2:
-			if (buf[0] < 9)
-				printf("      Warning: Descriptor too short\n");
-			printf("        bcdADC              %2x.%02x\n"
-			       "        bCategory           %5u\n"
-			       "        wTotalLength        %5u\n"
-			       "        bmControl            0x%02x\n",
-			       buf[4], buf[3], buf[5], buf[6] | (buf[7] << 8), buf[8]);
-			dump_audio_bmcontrols("          ", buf[8], uac2_interface_header_bmcontrols, protocol);
-			break;
-		}
+	case UAC_INTERFACE_SUBTYPE_HEADER:
+		dump_audio_subtype(dev, "HEADER", desc_audio_ac_header, buf, protocol, 4);
 		break;
 
-	case 0x02:  /* INPUT_TERMINAL */
-		printf("(INPUT_TERMINAL)\n");
-		termt = buf[4] | (buf[5] << 8);
-		get_audioterminal_string(termts, sizeof(termts), termt);
-
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			chnames = get_dev_string(dev, buf[10]);
-			term = get_dev_string(dev, buf[11]);
-			if (buf[0] < 12)
-				printf("      Warning: Descriptor too short\n");
-			chcfg = buf[8] | (buf[9] << 8);
-			printf("        bTerminalID         %5u\n"
-			       "        wTerminalType      0x%04x %s\n"
-			       "        bAssocTerminal      %5u\n"
-			       "        bNrChannels         %5u\n"
-			       "        wChannelConfig     0x%04x\n",
-			       buf[3], termt, termts, buf[6], buf[7], chcfg);
-			for (i = 0; i < 12; i++)
-				if ((chcfg >> i) & 1)
-					printf("          %s\n", chconfig[i]);
-			printf("        iChannelNames       %5u %s\n"
-			       "        iTerminal           %5u %s\n",
-			       buf[10], chnames, buf[11], term);
-			dump_junk(buf, "        ", 12);
-			break;
-		case USB_AUDIO_CLASS_2:
-			chnames = get_dev_string(dev, buf[13]);
-			term = get_dev_string(dev, buf[16]);
-			if (buf[0] < 17)
-				printf("      Warning: Descriptor too short\n");
-			chcfg = buf[9] | (buf[10] << 8) | (buf[11] << 16) | (buf[12] << 24);
-			printf("        bTerminalID         %5u\n"
-			       "        wTerminalType      0x%04x %s\n"
-			       "        bAssocTerminal      %5u\n"
-			       "        bCSourceID          %5d\n"
-			       "        bNrChannels         %5u\n"
-			       "        bmChannelConfig   0x%08x\n",
-			       buf[3], termt, termts, buf[6], buf[7], buf[8], chcfg);
-			for (i = 0; i < 26; i++)
-				if ((chcfg >> i) & 1)
-					printf("          %s\n", chconfig_uac2[i]);
-			printf("        bmControls    0x%04x\n", buf[14] | (buf[15] << 8));
-			dump_audio_bmcontrols("          ", buf[14] | (buf[15] << 8), uac2_input_term_bmcontrols, protocol);
-			printf("        iChannelNames       %5u %s\n"
-			       "        iTerminal           %5u %s\n",
-			       buf[13], chnames, buf[16], term);
-			dump_junk(buf, "        ", 17);
-			break;
-		} /* switch (protocol) */
-
+	case UAC_INTERFACE_SUBTYPE_INPUT_TERMINAL:
+		dump_audio_subtype(dev, "INPUT_TERMINAL", desc_audio_ac_input_terminal, buf, protocol, 4);
 		break;
 
-	case 0x03:  /* OUTPUT_TERMINAL */
-		printf("(OUTPUT_TERMINAL)\n");
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			term = get_dev_string(dev, buf[8]);
-			termt = buf[4] | (buf[5] << 8);
-			get_audioterminal_string(termts, sizeof(termts), termt);
-			if (buf[0] < 9)
-				printf("      Warning: Descriptor too short\n");
-			printf("        bTerminalID         %5u\n"
-			       "        wTerminalType      0x%04x %s\n"
-			       "        bAssocTerminal      %5u\n"
-			       "        bSourceID           %5u\n"
-			       "        iTerminal           %5u %s\n",
-			       buf[3], termt, termts, buf[6], buf[7], buf[8], term);
-			dump_junk(buf, "        ", 9);
-			break;
-		case USB_AUDIO_CLASS_2:
-			term = get_dev_string(dev, buf[11]);
-			termt = buf[4] | (buf[5] << 8);
-			get_audioterminal_string(termts, sizeof(termts), termt);
-			if (buf[0] < 12)
-				printf("      Warning: Descriptor too short\n");
-			printf("        bTerminalID         %5u\n"
-			       "        wTerminalType      0x%04x %s\n"
-			       "        bAssocTerminal      %5u\n"
-			       "        bSourceID           %5u\n"
-			       "        bCSourceID          %5u\n"
-			       "        bmControls         0x%04x\n",
-			       buf[3], termt, termts, buf[6], buf[7], buf[8], buf[9] | (buf[10] << 8));
-			dump_audio_bmcontrols("          ", buf[9] | (buf[10] << 8), uac2_output_term_bmcontrols, protocol);
-			printf("        iTerminal           %5u %s\n", buf[11], term);
-			dump_junk(buf, "        ", 12);
-			break;
-		} /* switch (protocol) */
-
+	case UAC_INTERFACE_SUBTYPE_OUTPUT_TERMINAL:
+		dump_audio_subtype(dev, "OUTPUT_TERMINAL", desc_audio_ac_output_terminal, buf, protocol, 4);
 		break;
 
-	case 0x04:  /* MIXER_UNIT */
-		printf("(MIXER_UNIT)\n");
-
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			j = buf[4];
-			k = buf[j+5];
-			if (j == 0 || k == 0) {
-				printf("      Warning: mixer with %5u input and %5u output channels.\n", j, k);
-				N = 0;
-			} else {
-				N = 1+(j*k-1)/8;
-			}
-			chnames = get_dev_string(dev, buf[8+j]);
-			term = get_dev_string(dev, buf[9+j+N]);
-			if (buf[0] < 10+j+N)
-				printf("      Warning: Descriptor too short\n");
-			chcfg = buf[6+j] | (buf[7+j] << 8);
-			printf("        bUnitID             %5u\n"
-			       "        bNrInPins           %5u\n",
-			       buf[3], buf[4]);
-			for (i = 0; i < j; i++)
-				printf("        baSourceID(%2u)      %5u\n", i, buf[5+i]);
-			printf("        bNrChannels         %5u\n"
-			       "        wChannelConfig     0x%04x\n",
-			       buf[5+j], chcfg);
-			for (i = 0; i < 12; i++)
-				if ((chcfg >> i) & 1)
-					printf("          %s\n", chconfig[i]);
-			printf("        iChannelNames       %5u %s\n",
-			       buf[8+j], chnames);
-			for (i = 0; i < N; i++)
-				printf("        bmControls         0x%02x\n", buf[9+j+i]);
-			printf("        iMixer              %5u %s\n", buf[9+j+N], term);
-			dump_junk(buf, "        ", 10+j+N);
-			break;
-
-		case USB_AUDIO_CLASS_2:
-			j = buf[4];
-			k = buf[0] - 13 - j;
-			chnames = get_dev_string(dev, buf[10+j]);
-			term = get_dev_string(dev, buf[12+j+k]);
-			chcfg =  buf[6+j] | (buf[7+j] << 8) | (buf[8+j] << 16) | (buf[9+j] << 24);
-
-			printf("        bUnitID             %5u\n"
-			       "        bNrPins             %5u\n",
-			       buf[3], buf[4]);
-			for (i = 0; i < j; i++)
-				printf("        baSourceID(%2u)      %5u\n", i, buf[5+i]);
-			printf("        bNrChannels         %5u\n"
-			       "        bmChannelConfig    0x%08x\n", buf[5+j], chcfg);
-			for (i = 0; i < 26; i++)
-				if ((chcfg >> i) & 1)
-					printf("          %s\n", chconfig_uac2[i]);
-			printf("        iChannelNames       %5u %s\n", buf[10+j], chnames);
-
-			N = 0;
-			for (i = 0; i < k; i++)
-				N |= buf[11+j+i] << (i * 8);
-
-			dump_bytes(buf+11+j, k);
-
-			printf("        bmControls         %02x\n", buf[11+j+k]);
-			dump_audio_bmcontrols("          ", buf[11+j+k], uac2_mixer_unit_bmcontrols, protocol);
-
-			printf("        iMixer             %5u %s\n", buf[12+j+k], term);
-			dump_junk(buf, "        ", 13+j+k);
-			break;
-		} /* switch (protocol) */
+	case UAC_INTERFACE_SUBTYPE_MIXER_UNIT:
+		dump_audio_subtype(dev, "MIXER_UNIT", desc_audio_ac_mixer_unit, buf, protocol, 4);
 		break;
 
-	case 0x05:  /* SELECTOR_UNIT */
-		printf("(SELECTOR_UNIT)\n");
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			if (buf[0] < 6+buf[4])
-				printf("      Warning: Descriptor too short\n");
-			term = get_dev_string(dev, buf[5+buf[4]]);
-
-			printf("        bUnitID             %5u\n"
-			       "        bNrInPins           %5u\n",
-			       buf[3], buf[4]);
-			for (i = 0; i < buf[4]; i++)
-				printf("        baSource(%2u)        %5u\n", i, buf[5+i]);
-			printf("        iSelector           %5u %s\n",
-			       buf[5+buf[4]], term);
-			dump_junk(buf, "        ", 6+buf[4]);
-			break;
-		case USB_AUDIO_CLASS_2:
-			if (buf[0] < 7+buf[4])
-				printf("      Warning: Descriptor too short\n");
-			term = get_dev_string(dev, buf[6+buf[4]]);
-
-			printf("        bUnitID             %5u\n"
-			       "        bNrInPins           %5u\n",
-			       buf[3], buf[4]);
-			for (i = 0; i < buf[4]; i++)
-				printf("        baSource(%2u)        %5u\n", i, buf[5+i]);
-			printf("        bmControls           0x%02x\n", buf[5+buf[4]]);
-			dump_audio_bmcontrols("          ", buf[5+buf[4]], uac2_selector_bmcontrols, protocol);
-			printf("        iSelector           %5u %s\n",
-			       buf[6+buf[4]], term);
-			dump_junk(buf, "        ", 7+buf[4]);
-			break;
-		} /* switch (protocol) */
-
+	case UAC_INTERFACE_SUBTYPE_SELECTOR_UNIT:
+		dump_audio_subtype(dev, "SELECTOR_UNIT", desc_audio_ac_selector_unit, buf, protocol, 4);
 		break;
 
-	case 0x06:  /* FEATURE_UNIT */
-		printf("(FEATURE_UNIT)\n");
-
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			j = buf[5];
-			if (!j)
-				j = 1;
-			k = (buf[0] - 7) / j;
-			if (buf[0] < 7+buf[5]*k)
-				printf("      Warning: Descriptor too short\n");
-			term = get_dev_string(dev, buf[6+buf[5]*k]);
-			printf("        bUnitID             %5u\n"
-			       "        bSourceID           %5u\n"
-			       "        bControlSize        %5u\n",
-			       buf[3], buf[4], buf[5]);
-			for (i = 0; i < k; i++) {
-				chcfg = buf[6+buf[5]*i];
-				if (buf[5] > 1)
-					chcfg |= (buf[7+buf[5]*i] << 8);
-				for (j = 0; j < buf[5]; j++)
-					printf("        bmaControls(%2u)      0x%02x\n", i, buf[6+buf[5]*i+j]);
-
-				dump_audio_bmcontrols("          ", chcfg, uac_fu_bmcontrols, protocol);
-			}
-			printf("        iFeature            %5u %s\n", buf[6+buf[5]*k], term);
-			dump_junk(buf, "        ", 7+buf[5]*k);
-			break;
-		case USB_AUDIO_CLASS_2:
-			if (buf[0] < 10)
-				printf("      Warning: Descriptor too short\n");
-			k = (buf[0] - 6) / 4;
-			printf("        bUnitID             %5u\n"
-			       "        bSourceID           %5u\n",
-			       buf[3], buf[4]);
-			for (i = 0; i < k; i++) {
-				chcfg = buf[5+(4*i)] |
-					buf[6+(4*i)] << 8 |
-					buf[7+(4*i)] << 16 |
-					buf[8+(4*i)] << 24;
-				printf("        bmaControls(%2u)      0x%08x\n", i, chcfg);
-				dump_audio_bmcontrols("          ", chcfg, uac_fu_bmcontrols, protocol);
-			}
-			term = get_dev_string(dev, buf[5+k*4]);
-			printf("        iFeature            %5u %s\n", buf[5+(k*4)], term);
-			dump_junk(buf, "        ", 6+(k*4));
-			break;
-		} /* switch (protocol) */
-
+	case UAC_INTERFACE_SUBTYPE_FEATURE_UNIT:
+		dump_audio_subtype(dev, "FEATURE_UNIT", desc_audio_ac_feature_unit, buf, protocol, 4);
 		break;
 
-	case 0x07:  /* PROCESSING_UNIT */
-		printf("(PROCESSING_UNIT)\n");
-
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			j = buf[6];
-			k = buf[11+j];
-			chnames = get_dev_string(dev, buf[10+j]);
-			term = get_dev_string(dev, buf[12+j+k]);
-			chcfg = buf[8+j] | (buf[9+j] << 8);
-			if (buf[0] < 13+j+k)
-				printf("      Warning: Descriptor too short\n");
-			printf("        bUnitID             %5u\n"
-			       "        wProcessType        %5u\n"
-			       "        bNrPins             %5u\n",
-			       buf[3], buf[4] | (buf[5] << 8), buf[6]);
-			for (i = 0; i < j; i++)
-				printf("        baSourceID(%2u)      %5u\n", i, buf[7+i]);
-			printf("        bNrChannels         %5u\n"
-			       "        wChannelConfig     0x%04x\n", buf[7+j], chcfg);
-			for (i = 0; i < 12; i++)
-				if ((chcfg >> i) & 1)
-					printf("          %s\n", chconfig[i]);
-			printf("        iChannelNames       %5u %s\n"
-			       "        bControlSize        %5u\n", buf[10+j], chnames, buf[11+j]);
-			for (i = 0; i < k; i++)
-				printf("        bmControls(%2u)       0x%02x\n", i, buf[12+j+i]);
-			if (buf[12+j] & 1)
-				printf("          Enable Processing\n");
-			printf("        iProcessing         %5u %s\n"
-			       "        Process-Specific    ", buf[12+j+k], term);
-			dump_bytes(buf+(13+j+k), buf[0]-(13+j+k));
-			break;
-		case USB_AUDIO_CLASS_2:
-			j = buf[6];
-			k = buf[0] - 17 - j;
-			chnames = get_dev_string(dev, buf[12+j]);
-			term = get_dev_string(dev, buf[15+j+k]);
-			chcfg =  buf[8+j] |
-				(buf[9+j] << 8) |
-				(buf[10+j] << 16) |
-				(buf[11+j] << 24);
-
-			printf("        bUnitID             %5u\n"
-			       "        wProcessType        %5u\n"
-			       "        bNrPins             %5u\n",
-			       buf[3], buf[4] | (buf[5] << 8), buf[6]);
-			for (i = 0; i < j; i++)
-				printf("        baSourceID(%2u)      %5u\n", i, buf[5+i]);
-			printf("        bNrChannels         %5u\n"
-			       "        bmChannelConfig    0x%08x\n", buf[7+j], chcfg);
-			for (i = 0; i < 26; i++)
-				if ((chcfg >> i) & 1)
-					printf("          %s\n", chconfig_uac2[i]);
-			printf("        iChannelNames       %5u %s\n"
-			       "        bmControls        0x%04x\n", buf[12+j], chnames, buf[13+j] | (buf[14+j] << 8));
-			if (buf[12+j] & 1)
-				printf("          Enable Processing\n");
-			printf("        iProcessing         %5u %s\n"
-			       "        Process-Specific    ", buf[15+j], term);
-			dump_bytes(buf+(16+j), k);
-			break;
-		} /* switch (protocol) */
-
+	case UAC_INTERFACE_SUBTYPE_PROCESSING_UNIT:
+		dump_audio_subtype(dev, "PROCESSING_UNIT", desc_audio_ac_processing_unit, buf, protocol, 4);
 		break;
 
-	case 0x08:  /* EXTENSION_UNIT */
-		printf("(EXTENSION_UNIT)\n");
-
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			j = buf[6];
-			k = buf[11+j];
-			chnames = get_dev_string(dev, buf[10+j]);
-			term = get_dev_string(dev, buf[12+j+k]);
-			chcfg = buf[8+j] | (buf[9+j] << 8);
-			if (buf[0] < 13+j+k)
-				printf("      Warning: Descriptor too short\n");
-			printf("        bUnitID             %5u\n"
-			       "        wExtensionCode      %5u\n"
-			       "        bNrPins             %5u\n",
-			       buf[3], buf[4] | (buf[5] << 8), buf[6]);
-			for (i = 0; i < j; i++)
-				printf("        baSourceID(%2u)      %5u\n", i, buf[7+i]);
-			printf("        bNrChannels         %5u\n"
-			       "        wChannelConfig      %5u\n", buf[7+j], chcfg);
-			for (i = 0; i < 12; i++)
-				if ((chcfg >> i) & 1)
-					printf("          %s\n", chconfig[i]);
-			printf("        iChannelNames       %5u %s\n"
-			       "        bControlSize        %5u\n", buf[10+j], chnames, buf[11+j]);
-			for (i = 0; i < k; i++)
-				printf("        bmControls(%2u)       0x%02x\n", i, buf[12+j+i]);
-			if (buf[12+j] & 1)
-				printf("          Enable Processing\n");
-			printf("        iExtension          %5u %s\n",
-			       buf[12+j+k], term);
-			dump_junk(buf, "        ", 13+j+k);
-			break;
-		case USB_AUDIO_CLASS_2:
-			j = buf[6];
-			chnames = get_dev_string(dev, buf[13+j]);
-			term = get_dev_string(dev, buf[15+j]);
-			chcfg = buf[9+j] | (buf[10+j] << 8) | (buf[11+j] << 16) | (buf[12+j] << 24);
-			if (buf[0] < 16+j)
-				printf("      Warning: Descriptor too short\n");
-			printf("        bUnitID             %5u\n"
-			       "        wExtensionCode      %5u\n"
-			       "        bNrPins             %5u\n",
-			       buf[3], buf[4] | (buf[5] << 8), buf[6]);
-			for (i = 0; i < j; i++)
-				printf("        baSourceID(%2u)      %5u\n", i, buf[7+i]);
-			printf("        bNrChannels         %5u\n"
-			       "        wChannelConfig      %5u\n", buf[7+j], chcfg);
-			for (i = 0; i < 12; i++)
-				if ((chcfg >> i) & 1)
-					printf("          %s\n", chconfig[i]);
-			printf("        iChannelNames       %5u %s\n"
-			       "        bmControls        0x%02x\n", buf[13+j], chnames, buf[14+j]);
-			dump_audio_bmcontrols("          ", buf[14+j], uac2_extension_unit_bmcontrols, protocol);
-
-			printf("        iExtension          %5u %s\n",
-			       buf[15+j], term);
-			dump_junk(buf, "        ", 16+j);
-			break;
-		} /* switch (protocol) */
-
+	case UAC_INTERFACE_SUBTYPE_EXTENSION_UNIT:
+		dump_audio_subtype(dev, "EXTENSION_UNIT", desc_audio_ac_extension_unit, buf, protocol, 4);
 		break;
 
-	case 0x0a:  /* CLOCK_SOURCE */
-		printf ("(CLOCK_SOURCE)\n");
-		if (protocol != USB_AUDIO_CLASS_2)
-			printf("      Warning: CLOCK_SOURCE descriptors are illegal for UAC1\n");
-
-		if (buf[0] < 8)
-			printf("      Warning: Descriptor too short\n");
-
-		printf("        bClockID            %5u\n"
-		       "        bmAttributes         0x%02x %s Clock %s\n",
-		       buf[3], buf[4], clock_source_attrs[buf[4] & 3],
-		       (buf[4] & 4) ? "(synced to SOF)" : "");
-
-		printf("        bmControls           0x%02x\n", buf[5]);
-		dump_audio_bmcontrols("          ", buf[5], uac2_clock_source_bmcontrols, protocol);
-
-		term = get_dev_string(dev, buf[7]);
-		printf("        bAssocTerminal      %5u\n", buf[6]);
-		printf("        iClockSource        %5u %s\n", buf[7], term);
-		dump_junk(buf, "        ", 8);
+	case UAC_INTERFACE_SUBTYPE_CLOCK_SOURCE:
+		dump_audio_subtype(dev, "CLOCK_SOURCE", desc_audio_ac_clock_source, buf, protocol, 4);
 		break;
 
-	case 0x0b:  /* CLOCK_SELECTOR */
-		printf("(CLOCK_SELECTOR)\n");
-		if (protocol != USB_AUDIO_CLASS_2)
-			printf("      Warning: CLOCK_SELECTOR descriptors are illegal for UAC1\n");
-
-		if (buf[0] < 7+buf[4])
-			printf("      Warning: Descriptor too short\n");
-		term = get_dev_string(dev, buf[6+buf[4]]);
-
-		printf("        bUnitID             %5u\n"
-		       "        bNrInPins           %5u\n",
-		       buf[3], buf[4]);
-		for (i = 0; i < buf[4]; i++)
-			printf("        baCSourceID(%2u)     %5u\n", i, buf[5+i]);
-		printf("        bmControls           0x%02x\n", buf[5+buf[4]]);
-		dump_audio_bmcontrols("          ", buf[5+buf[4]], uac2_clock_selector_bmcontrols, protocol);
-
-		printf("        iClockSelector      %5u %s\n",
-		       buf[6+buf[4]], term);
-		dump_junk(buf, "        ", 7+buf[4]);
+	case UAC_INTERFACE_SUBTYPE_CLOCK_SELECTOR:
+		dump_audio_subtype(dev, "CLOCK_SELECTOR", desc_audio_ac_clock_selector, buf, protocol, 4);
 		break;
 
-	case 0x0c:  /* CLOCK_MULTIPLIER */
-		printf("(CLOCK_MULTIPLIER)\n");
-		if (protocol != USB_AUDIO_CLASS_2)
-			printf("      Warning: CLOCK_MULTIPLIER descriptors are illegal for UAC1\n");
-
-		if (buf[0] < 7)
-			printf("      Warning: Descriptor too short\n");
-
-		printf("        bClockID            %5u\n"
-		       "        bCSourceID          %5u\n",
-		       buf[3], buf[4]);
-
-		printf("        bmControls           0x%02x\n", buf[5]);
-		dump_audio_bmcontrols("          ", buf[5], uac2_clock_multiplier_bmcontrols, protocol);
-
-		term = get_dev_string(dev, buf[6]);
-		printf("        iClockMultiplier    %5u %s\n", buf[6], term);
-		dump_junk(buf, "        ", 7);
+	case UAC_INTERFACE_SUBTYPE_CLOCK_MULTIPLIER:
+		dump_audio_subtype(dev, "CLOCK_MULTIPLIER", desc_audio_ac_clock_multiplier, buf, protocol, 4);
 		break;
 
-	case 0x0d:  /* SAMPLE_RATE_CONVERTER_UNIT */
-		printf("(SAMPLE_RATE_CONVERTER_UNIT)\n");
-		if (protocol != USB_AUDIO_CLASS_2)
-			printf("      Warning: SAMPLE_RATE_CONVERTER_UNIT descriptors are illegal for UAC1\n");
-
-		if (buf[0] < 8)
-			printf("      Warning: Descriptor too short\n");
-
-		term = get_dev_string(dev, buf[7]);
-		printf("        bUnitID             %5u\n"
-		       "        bSourceID           %5u\n"
-		       "        bCSourceInID        %5u\n"
-		       "        bCSourceOutID       %5u\n"
-		       "        iSRC                %5u %s\n",
-		       buf[3], buf[4], buf[5], buf[6], buf[7], term);
-		dump_junk(buf, "        ", 8);
+	case UAC_INTERFACE_SUBTYPE_SAMPLE_RATE_CONVERTER:
+		dump_audio_subtype(dev, "SAMPLING_RATE_CONVERTER", desc_audio_ac_clock_multiplier, buf, protocol, 4);
 		break;
 
-	case 0xf0:  /* EFFECT_UNIT - the real value is 0x07, see above for the reason for remapping */
-		printf("(EFFECT_UNIT)\n");
-
-		if (buf[0] < 16)
-			printf("      Warning: Descriptor too short\n");
-		k = (buf[0] - 16) / 4;
-		term = get_dev_string(dev, buf[15+k*4]);
-		printf("        bUnitID             %5u\n"
-		       "        wEffectType         %5u\n"
-		       "        bSourceID           %5u\n",
-		       buf[3], buf[4] | (buf[5] << 8), buf[6]);
-		for (i = 0; i < k; i++) {
-			chcfg = buf[7+(4*i)] |
-				buf[8+(4*i)] << 8 |
-				buf[9+(4*i)] << 16 |
-				buf[10+(4*i)] << 24;
-			printf("        bmaControls(%2u)      0x%08x\n", i, chcfg);
-			/* TODO: parse effect-specific controls */
-		}
-		printf("        iEffect             %5u %s\n", buf[15+(k*4)], term);
-		dump_junk(buf, "        ", 16+(k*4));
+	case UAC_INTERFACE_SUBTYPE_EFFECT_UNIT:
+		dump_audio_subtype(dev, "EFFECT_UNIT", desc_audio_ac_effect_unit, buf, protocol, 4);
 		break;
 
 	default:
@@ -1620,16 +1059,8 @@ static void dump_audiocontrol_interface(libusb_device_handle *dev, const unsigne
 		dump_bytes(buf+3, buf[0]-3);
 		break;
 	}
-
-	free(chnames);
-	free(term);
 }
 
-static const struct bmcontrol uac2_as_interface_bmcontrols[] = {
-	{ "Active Alternate Setting",	0 },
-	{ "Valid Alternate Setting",	1 },
-	{ NULL }
-};
 
 static void dump_audiostreaming_interface(libusb_device_handle *dev, const unsigned char *buf, int protocol)
 {
@@ -1655,54 +1086,7 @@ static void dump_audiostreaming_interface(libusb_device_handle *dev, const unsig
 	       buf[0], buf[1], buf[2]);
 	switch (buf[2]) {
 	case 0x01: /* AS_GENERAL */
-		printf("(AS_GENERAL)\n");
-
-		switch (protocol) {
-		case USB_AUDIO_CLASS_1:
-			if (buf[0] < 7)
-				printf("      Warning: Descriptor too short\n");
-			fmttag = buf[5] | (buf[6] << 8);
-			if (fmttag <= 5)
-				fmtptr = fmtItag[fmttag];
-			else if (fmttag >= 0x1000 && fmttag <= 0x1002)
-				fmtptr = fmtIItag[fmttag & 0xfff];
-			else if (fmttag >= 0x2000 && fmttag <= 0x2006)
-				fmtptr = fmtIIItag[fmttag & 0xfff];
-			printf("        bTerminalLink       %5u\n"
-			       "        bDelay              %5u frames\n"
-			       "        wFormatTag          %5u %s\n",
-			       buf[3], buf[4], fmttag, fmtptr);
-			dump_junk(buf, "        ", 7);
-			break;
-		case USB_AUDIO_CLASS_2:
-			if (buf[0] < 16)
-				printf("      Warning: Descriptor too short\n");
-			printf("        bTerminalLink       %5u\n"
-			       "        bmControls           0x%02x\n",
-			       buf[3], buf[4]);
-			dump_audio_bmcontrols("          ", buf[4], uac2_as_interface_bmcontrols, protocol);
-
-			printf("        bFormatType         %5u\n", buf[5]);
-			fmttag = buf[6] | (buf[7] << 8) | (buf[8] << 16) | (buf[9] << 24);
-			printf("        bmFormats         0x%08x\n", fmttag);
-			for (i=0; i<5; i++)
-				if ((fmttag >> i) & 1)
-					printf("          %s\n", fmtItag[i+1]);
-
-			j = buf[11] | (buf[12] << 8) | (buf[13] << 16) | (buf[14] << 24);
-			printf("        bNrChannels         %5u\n"
-			       "        bmChannelConfig   0x%08x\n",
-			       buf[10], j);
-			for (i = 0; i < 26; i++)
-				if ((j >> i) & 1)
-					printf("          %s\n", chconfig_uac2[i]);
-
-			name = get_dev_string(dev, buf[15]);
-			printf("        iChannelNames       %5u %s\n", buf[15], name);
-			dump_junk(buf, "        ", 16);
-			break;
-		} /* switch (protocol) */
-
+		dump_audio_subtype(dev, "AS_GENERAL", desc_audio_as_interface, buf, protocol, 4);
 		break;
 
 	case 0x02: /* FORMAT_TYPE */
@@ -1961,62 +1345,21 @@ static void dump_audiostreaming_interface(libusb_device_handle *dev, const unsig
 	free(name);
 }
 
-static const struct bmcontrol uac2_audio_endpoint_bmcontrols[] = {
-	{ "Pitch",		0 },
-	{ "Data Overrun",	1 },
-	{ "Data Underrun",	2 },
-	{ NULL }
-};
-
-static void dump_audiostreaming_endpoint(const unsigned char *buf, int protocol)
+static void dump_audiostreaming_endpoint(libusb_device_handle *dev, const unsigned char *buf, int protocol)
 {
-	static const char * const lockdelunits[] = { "Undefined", "Milliseconds", "Decoded PCM samples", "Reserved" };
-	unsigned int lckdelidx;
+	static const char * const subtype[] = { "invalid", "EP_GENERAL" };
 
 	if (buf[1] != USB_DT_CS_ENDPOINT)
 		printf("      Warning: Invalid descriptor\n");
-	else if (buf[0] < ((protocol == USB_AUDIO_CLASS_1) ? 7 : 8))
-		printf("      Warning: Descriptor too short\n");
-	printf("        AudioControl Endpoint Descriptor:\n"
+
+	printf("        AudioStreaming Endpoint Descriptor:\n"
 	       "          bLength             %5u\n"
 	       "          bDescriptorType     %5u\n"
-	       "          bDescriptorSubtype  %5u (%s)\n"
-	       "          bmAttributes         0x%02x\n",
-	       buf[0], buf[1], buf[2], buf[2] == 1 ? "EP_GENERAL" : "invalid", buf[3]);
+	       "          bDescriptorSubtype  %5u ",
+	       buf[0], buf[1], buf[2]);
 
-	switch (protocol) {
-	case USB_AUDIO_CLASS_1:
-		if (buf[3] & 1)
-			printf("            Sampling Frequency\n");
-		if (buf[3] & 2)
-			printf("            Pitch\n");
-		if (buf[3] & 128)
-			printf("            MaxPacketsOnly\n");
-		lckdelidx = buf[4];
-		if (lckdelidx > 3)
-			lckdelidx = 3;
-		printf("          bLockDelayUnits     %5u %s\n"
-		       "          wLockDelay          %5u %s\n",
-		       buf[4], lockdelunits[lckdelidx], buf[5] | (buf[6] << 8), lockdelunits[lckdelidx]);
-		dump_junk(buf, "        ", 7);
-		break;
-
-	case USB_AUDIO_CLASS_2:
-		if (buf[3] & 128)
-			printf("            MaxPacketsOnly\n");
-
-		printf("          bmControls           0x%02x\n", buf[4]);
-		dump_audio_bmcontrols("          ", buf[4], uac2_audio_endpoint_bmcontrols, protocol);
-
-		lckdelidx = buf[5];
-		if (lckdelidx > 3)
-			lckdelidx = 3;
-		printf("          bLockDelayUnits     %5u %s\n"
-		       "          wLockDelay          %5u\n",
-		       buf[5], lockdelunits[lckdelidx], buf[6] | (buf[7] << 8));
-		dump_junk(buf, "        ", 8);
-		break;
-	} /* switch protocol */
+	dump_audio_subtype(dev, subtype[buf[2] == 1],
+			desc_audio_as_isochronous_audio_data_endpoint, buf, protocol, 5);
 }
 
 static void dump_midistreaming_interface(libusb_device_handle *dev, const unsigned char *buf)


### PR DESCRIPTION
This adds a new way of dumping descriptors, which splits the knowledge of how to interpret descriptor data from the actual dumping.  This has two advantages:

1. It is easy to add support for new descriptors, since they are now simple definitions that resemble the tables in the USB specifications.
2. The code for dumping descriptors is common, so the output is easy to keep consistent.  It is also consistent and thorough in its handling of insufficient descriptor data buffer, and junk data at the end of a descriptor.

UAC1 and UAC2 are converted to use the new mechanism, and finally initial support for UAC3 is added.