### PR TITLE
usb-devices: use /bin/sh hashbang

### DIFF
--- a/usb-devices
+++ b/usb-devices
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0+
 #
 # Copyright (c) 2009 Greg Kroah-Hartman <greg@kroah.com>


### PR DESCRIPTION
This script doesn't use any bashisms, so change the hashbang to /bin/sh.

Fixes #73.

Signed-off-by: Ross Burton <ross.burton@intel.com>