### PR TITLE
lsusb-t: Emit USB IDs and other handy info when verbosity is increased

### DIFF
--- a/lsusb-t.c
+++ b/lsusb-t.c
@@ -80,9 +80,12 @@ struct usbbusnode {
 
 	unsigned int bDeviceClass;
 	unsigned int devnum;
+	unsigned int idProduct;
+	unsigned int idVendor;
 	unsigned int maxchild;
 	char speed[5 + 1];	/* '1.5','12','480','5000' + '\n' */
 
+	char name[MY_SYSFS_FILENAME_LEN];
 	char driver[MY_SYSFS_FILENAME_LEN];
 };
 
@@ -135,13 +138,23 @@ static const char *bDeviceClass_to_str(unsigned int dc)
 }
 static void print_usbbusnode(struct usbbusnode *b)
 {
+	char vendor[128], product[128];
 	printf("/:  Bus %02u.Port %u: Dev %u, Class=%s, Driver=%s/%up, %sM\n", b->busnum, 1,
 	       b->devnum, bDeviceClass_to_str(b->bDeviceClass), b->driver, b->maxchild, b->speed);
+	if (verblevel >= 1) {
+		get_vendor_string(vendor, sizeof(vendor), b->idVendor);
+		get_product_string(product, sizeof(product), b->idVendor, b->idProduct);
+		printf("    ID %04x:%04x %s %s\n", b->idVendor, b->idProduct, vendor, product);
+	}
+	if (verblevel >= 2) {
+		printf("    %s/%s  /dev/bus/usb/%03d/%03d\n", sys_bus_usb_devices, b->name, b->busnum, b->devnum);
+	}
 }
 
 static void print_usbdevice(struct usbdevice *d, struct usbinterface *i)
 {
 	char subcls[128];
+	char vendor[128], product[128];
 
 	get_class_string(subcls, sizeof(subcls), i->bInterfaceClass);
 
@@ -151,6 +164,16 @@ static void print_usbdevice(struct usbdevice *d, struct usbinterface *i)
 	else
 		printf("Port %u: Dev %u, If %u, Class=%s, Driver=%s, %sM\n", d->portnum, d->devnum, i->ifnum, subcls, i->driver,
 		       d->speed);
+	if (verblevel >= 1) {
+		printf(" %*s", indent, "    ");
+		get_vendor_string(vendor, sizeof(vendor), d->idVendor);
+		get_product_string(product, sizeof(product), d->idVendor, d->idProduct);
+		printf("ID %04x:%04x %s %s\n", d->idVendor, d->idProduct, vendor, product);
+	}
+	if (verblevel >= 2) {
+		printf(" %*s", indent, "    ");
+		printf("%s/%s  /dev/bus/usb/%03d/%03d\n", sys_bus_usb_devices, d->name, d->busnum, d->devnum);
+	}
 }
 
 static unsigned int read_sysfs_file_int(const char *d_name, const char *file, int base)
@@ -404,8 +427,12 @@ static void add_usb_bus(const char *d_name)
 	if (bus) {
 		memset(bus, 0, sizeof(struct usbbusnode));
 		bus->busnum = strtoul(d_name + 3, NULL, 10);
+		if (snprintf(bus->name, MY_SYSFS_FILENAME_LEN, "%s", d_name) >= MY_SYSFS_FILENAME_LEN)
+			printf("warning: '%s' truncated to '%s'\n", d_name, bus->name);
 		SYSFS_INTu(d_name, bus, devnum);
 		SYSFS_INTx(d_name, bus, bDeviceClass);
+		SYSFS_INTx(d_name, bus, idProduct);
+		SYSFS_INTx(d_name, bus, idVendor);
 		SYSFS_INTu(d_name, bus, maxchild);
 		SYSFS_STR(d_name, bus, speed);
 		append_busnode(bus);

--- a/lsusb-t.c
+++ b/lsusb-t.c
@@ -290,7 +290,7 @@ static void add_usb_interface(const char *d_name)
 	}
 	e->ifnum = i;
 	if (snprintf(e->name, MY_SYSFS_FILENAME_LEN, "%s", d_name) >= MY_SYSFS_FILENAME_LEN)
-		printf("warning: '%s' truncated to '%s'\n", e->name, d_name);
+		printf("warning: '%s' truncated to '%s'\n", d_name, e->name);
 	SYSFS_INTu(d_name, e, bAlternateSetting);
 	SYSFS_INTx(d_name, e, bInterfaceClass);
 	SYSFS_INTx(d_name, e, bInterfaceNumber);
@@ -339,7 +339,7 @@ static void add_usb_device(const char *d_name)
 		d->portnum = i;
 	}
 	if (snprintf(d->name, MY_SYSFS_FILENAME_LEN, "%s", d_name) >= MY_SYSFS_FILENAME_LEN)
-		printf("warning: '%s' truncated to '%s'\n", d->name, d_name);
+		printf("warning: '%s' truncated to '%s'\n", d_name, d->name);
 	SYSFS_INTu(d_name, d, bConfigurationValue);
 	SYSFS_INTx(d_name, d, bDeviceClass);
 	SYSFS_INTx(d_name, d, bDeviceProtocol);

--- a/lsusb.c
+++ b/lsusb.c
@@ -3759,8 +3759,6 @@ int main(int argc, char *argv[])
 	status = 0;
 
 	if (treemode) {
-		/* treemode requires at least verblevel 1 */
-		verblevel += 1 - VERBLEVEL_DEFAULT;
 		status = lsusb_t();
 		names_exit();
 		return status;

--- a/lsusb.c
+++ b/lsusb.c
@@ -115,7 +115,7 @@
 #define WEBUSB_GET_URL		0x02
 #define USB_DT_WEBUSB_URL	0x03
 
-static unsigned int verblevel = VERBLEVEL_DEFAULT;
+unsigned int verblevel = VERBLEVEL_DEFAULT;
 static int do_report_desc = 1;
 static const char * const encryption_type[] = {
 	"UNSECURE",

--- a/lsusb.h
+++ b/lsusb.h
@@ -4,5 +4,6 @@
 #define _LSUSB_H
 
 extern int lsusb_t(void);
+extern unsigned int verblevel;
 
 #endif


### PR DESCRIPTION
TL;DR: 
```
$ ./lsusb -t | head -3
/:  Bus 04.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/2p, 5000M
/:  Bus 03.Port 1: Dev 1, Class=root_hub, Driver=ehci-pci/3p, 480M
    |__ Port 1: Dev 2, If 0, Class=Hub, Driver=hub/8p, 480M

$ ./lsusb -tv | head -6    # new!
/:  Bus 04.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/2p, 5000M
    ID 1d6b:0003 Linux Foundation 3.0 root hub
/:  Bus 03.Port 1: Dev 1, Class=root_hub, Driver=ehci-pci/3p, 480M
    ID 1d6b:0002 Linux Foundation 2.0 root hub
    |__ Port 1: Dev 2, If 0, Class=Hub, Driver=hub/8p, 480M
        ID 8087:0024 Intel Corp. Integrated Rate Matching Hub

$ ./lsusb -tvv | head -9    # new!
/:  Bus 04.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/2p, 5000M
    ID 1d6b:0003 Linux Foundation 3.0 root hub
    /sys/bus/usb/devices/usb4  /dev/bus/usb/004/001
/:  Bus 03.Port 1: Dev 1, Class=root_hub, Driver=ehci-pci/3p, 480M
    ID 1d6b:0002 Linux Foundation 2.0 root hub
    /sys/bus/usb/devices/usb3  /dev/bus/usb/003/001
    |__ Port 1: Dev 2, If 0, Class=Hub, Driver=hub/8p, 480M
        ID 8087:0024 Intel Corp. Integrated Rate Matching Hub
        /sys/bus/usb/devices/3-1  /dev/bus/usb/003/002
```

lspci (from pciutils) has the ability to show bus topology and vendor/product ID in the same output (e.g. `lspci -tvnn`).  This PR attempts to bring something similar to lsusb (albeit somewhat constrained by the existing output format of `lsusb --tree`).

Motivation:  I have some flaky hardware that sometimes enumerates USB 3.0-capable hardware under ehci instead of xhci.  I sometimes also care about which devices share a common bus, such when running virtualized with PCI passthrough (e.g. Qubes).

This is intended as an RFC, but feel free to merge it as-is if it suits you.  The specific output format and the choice to output /sys and /dev paths when verbosity >= 2 were more-or-less arbitrary.  The main thing I'd like is getting vendor/product info from lsusb's --tree mode.