### PR TITLE
Add usbreset.c as noinst_PROGRAMS target.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,9 @@ bin_SCRIPTS = \
 	usb-devices \
 	lsusb.py
 
+noinst_PROGRAMS = \
+	usbreset
+
 lsusb_SOURCES = \
 	lsusb.c lsusb.h \
 	lsusb-t.c \
@@ -38,6 +41,9 @@ lsusb_CPPFLAGS = \
 lsusb_LDADD = \
 	$(LIBUSB_LIBS) \
 	$(UDEV_LIBS)
+
+usbreset_SOURCES = \
+	usbreset.c
 
 man_MANS = \
 	lsusb.8	\


### PR DESCRIPTION
@gregkh in https://github.com/gregkh/usbutils/issues/34 you voiced concerns about shipping an usbreset.c utility. I saw that in the meantime, usbreset.c was added in https://github.com/gregkh/usbutils/commit/1bfa07c58fdcfb955812f3ce6e28336dd323ff83. My following PR adds build rules for usbreset to Makefile.am, but sets them `noinst_`, so that usbreset doesn't get shipped. I am doing this because builds outside of the automake framework are just cumbersome (especially when headers don't live in standard locations, like it's the case for my distro)

On a personal note: I do understand your concerns about needless support requests, and I would address that by add a warning to usbreset that this is a best effort utility. Not shipping usbreset at all probably causes more "harm" than the harm from disappointed users that it doesn't work. For my part, without usbreset my beloved Kinesis keyboard wouldn't work. Please consider https://github.com/clefru/usbutils/commit/2124a8500afc72bbe0a8ab1898ab0f949d412314 as an alternative to this PR.

Thanks for your work!
