### PR TITLE
lsusb: Read unkown names from sysfs device desc.

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -3693,7 +3693,7 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 	struct libusb_device_descriptor desc;
 	char vendor[128], product[128];
 	int status;
-	ssize_t num_devs, i;
+	ssize_t num_devs, i, vendor_len, product_len;
 
 	status = 1; /* 1 device not found, 0 device found */
 
@@ -3705,6 +3705,7 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 		libusb_device *dev = list[i];
 		uint8_t bnum = libusb_get_bus_number(dev);
 		uint8_t dnum = libusb_get_device_address(dev);
+		uint8_t pnum = libusb_get_port_number(dev);
 
 		if ((busnum != -1 && busnum != bnum) ||
 		    (devnum != -1 && devnum != dnum))
@@ -3714,9 +3715,18 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 		    (productid != -1 && productid != desc.idProduct))
 			continue;
 		status = 0;
-		get_vendor_string(vendor, sizeof(vendor), desc.idVendor);
-		get_product_string(product, sizeof(product),
+
+		vendor_len = get_vendor_string(vendor, sizeof(vendor), desc.idVendor);
+		if (vendor_len == 0)
+			read_sysfs_prop(vendor, sizeof(vendor), bnum, pnum,
+					"manufacturer");
+
+		product_len = get_product_string(product, sizeof(product),
 				desc.idVendor, desc.idProduct);
+		if (product_len == 0)
+			read_sysfs_prop(product, sizeof(product), bnum, pnum,
+					"product");
+
 		if (verblevel > 0)
 			printf("\n");
 		printf("Bus %03u Device %03u: ID %04x:%04x %s %s\n",

--- a/names.c
+++ b/names.c
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <linux/limits.h>
 
 #include <libudev.h>
 
@@ -30,6 +31,8 @@
 #define HASH1  0x10
 #define HASH2  0x02
 #define HASHSZ 512
+
+#define SYSFS_DEV_ATTR_PATH "/sys/bus/usb/devices/%d-%d/%s"
 
 static unsigned int hashnum(unsigned int num)
 {
@@ -402,6 +405,27 @@ static void print_tables(void)
 	printf("--------------------------------------------\n");
 }
 */
+
+int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname)
+{
+	int n, fd;
+	char path[PATH_MAX];
+
+	buf[0] = '\0';
+	snprintf(path, sizeof(path), SYSFS_DEV_ATTR_PATH, bnum, pnum, propname);
+	fd = open(path, O_RDONLY);
+
+	if (fd == -1)
+		return 0;
+
+	n = read(fd, buf, size);
+
+	if (n > 0)
+		buf[n-1] = '\0';  // Turn newline into null terminator
+
+	close(fd);
+	return n;
+}
 
 int names_init(void)
 {

--- a/names.h
+++ b/names.h
@@ -9,6 +9,7 @@
 #define _NAMES_H
 
 #include <sys/types.h>
+#include <stdint.h>
 
 /* ---------------------------------------------------------------------- */
 
@@ -33,6 +34,8 @@ extern int get_vendor_string(char *buf, size_t size, u_int16_t vid);
 extern int get_product_string(char *buf, size_t size, u_int16_t vid, u_int16_t pid);
 extern int get_class_string(char *buf, size_t size, u_int8_t cls);
 extern int get_subclass_string(char *buf, size_t size, u_int8_t cls, u_int8_t subcls);
+
+extern int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname);
 
 extern int names_init(void);
 extern void names_exit(void);


### PR DESCRIPTION
lsusb tries to get the names for manufacturer and product of a device by
asking the udev hwdb for the names of the device id.
Not every manufacturer and device are in this database. Most devices
however provide those names in the standard USB descriptors, namely
iManufacturer and iProduct.
To get those with libusb we would have to open the device which
requires superuser privileges. To get those values anyway the kernel
provides them in sysfs.

Maybe we want to ask libusb to add the functionality to get those names without having to call `libusb_open`. I couldn't find that functionality.