### PR TITLE
Require newer version of libusb

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_SYS_LARGEFILE
 AC_CHECK_HEADERS([byteswap.h])
 AC_CHECK_FUNCS([nl_langinfo iconv])
 
-PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.9)
+PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.22)
 
 PKG_CHECK_MODULES(UDEV, libudev >= 196)
 


### PR DESCRIPTION
The change to update usbhid-dump in commit 89a279c implicitly changed
the required version of libusb from 1.0.9 to a version that contains
libusb_set_options(). The function was introduced in libusb 1.0.22, so
let's update the pkg-config check to match.

Fixes: #83