### PR TITLE
Revert "Require newer version of libusb"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_SYS_LARGEFILE
 AC_CHECK_HEADERS([byteswap.h])
 AC_CHECK_FUNCS([nl_langinfo iconv])
 
-PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.22)
+PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.14)
 
 PKG_CHECK_MODULES(UDEV, libudev >= 196)
 


### PR DESCRIPTION
This reverts commit 3fe9f89 of usbutils and updates
the usbhid-dump submodule to 209c2b0 which works
around possibly missing libusb_set_option due to a
to old version of libusb.

Since Debian stable (Stretch) contains libusb 1.0.21 (which is one minor version short) the build of usbutils is broken there with no good reason since usbhid-dump is working around it lately. I have
not really tested this with 1.0.9 but with 1.0.21 it builds and runs just fine.