### PR TITLE
lsusb: add a blacklist of not requesting debug descriptor

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -3604,6 +3604,16 @@ out:
 	free(bos_desc);
 }
 
+/*
+ * Blacklist of buggy devices unable to handle debug descriptor
+ */
+static int no_debug(unsigned int idVendor, unsigned int idProduct)
+{
+	if (idVendor == 0x2717 && idProduct == 0x3801) return 1;
+	if (idVendor == 0x2717 && idProduct == 0x3802) return 1;
+	return 0;
+}
+
 static void dumpdev(libusb_device *dev)
 {
 	libusb_device_handle *udev;
@@ -3658,7 +3668,11 @@ static void dumpdev(libusb_device *dev)
 	if (desc.bcdUSB == 0x0200) {
 		do_dualspeed(udev);
 	}
-	do_debug(udev);
+	if (no_debug(desc.idVendor, desc.idProduct))
+		fprintf(stderr, "skip to request debug descriptor for "
+			"ID %04x:%04x\n", desc.idVendor, desc.idProduct);
+	else
+		do_debug(udev);
 	dump_device_status(udev, otg, wireless, desc.bcdUSB >= 0x0300);
 	libusb_close(udev);
 }


### PR DESCRIPTION
These two headsets are unable to handle a request of debug descriptor:

Bus 001 Device 021: ID 2717:3801 Xiaomi em006
Bus 001 Device 022: ID 2717:3802 Xiaomi Mi Dual Driver Earphones Type-C

In the journey of bug hunting I went through lsusb, libusb, to the kernel
of usbcore, usbfs, and xHCI, realized the cruical scenerio as below note.

Review the USB spec of 2.0 and 3.x for debug descriptor/class, it looks
to me no better mechanism allows kernel to block this odd like a quirk,
I then chose to implement a blacklist policy in lsusb.

Note:
The PID of 3802 gets disconnect event then re-attach.
e.g.,
[94336.186600] usb 1-1: control urb: bRequestType=80 bRequest=06 wValue=0a00 wIndex=0000 wLength=0004
[94336.186605] usb 1-1: userurb 0000588b505b3980, ep0 ctrl-in, length 4
[94336.187145] xhci_hcd 0000:00:15.0: Transfer error for slot 21 ep 0 on endpoint
[94336.187155] usb 1-1: urb complete
[94336.187161] usb 1-1: userurb         pK-error, ep0 ctrl-in, actual_length 0 status -71
[94336.187812] xhci_hcd 0000:00:15.0: Transfer error for slot 21 ep 8 on endpoint
[94336.188116] hub 1-0:1.0: state 7 ports 9 chg 0000 evt 0002
[94336.188166] usb usb1-port1: status 0100, change 0001, 12 Mb/s
[94336.188170] usb 1-1: USB disconnect, device number 22
...
[94337.224296] usb 1-1: New USB device found, idVendor=2717, idProduct=3802, bcdDevice= 1.00
[94337.224302] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[94337.224305] usb 1-1: Product: Mi Dual Driver Earphones Type-C
[94337.224308] usb 1-1: Manufacturer: Xiaomi
[94337.224311] usb 1-1: SerialNumber: 20160406.1

While the PID of 3801 is even worse, the audio stream gets malfunction, generates
loud noise until user physically unplug, and replug to revive headset function.
e.g.,
[94658.517014] usb 1-5: control urb: bRequestType=80 bRequest=06 wValue=0a00 wIndex=0000 wLength=0004
[94658.517019] usb 1-5: userurb 000057afe19c2810, ep0 ctrl-in, length 4
[94663.517314] usb 1-5: usbdev_do_ioctl: DISCARDURB 000057afe19c2810
[94663.517363] xhci_hcd 0000:00:15.0: Stopped on Transfer TRB for slot 23 ep 0
[94663.517381] usb 1-5: urb complete
[94663.517389] usb 1-5: userurb         pK-error, ep0 ctrl-in, actual_length 0 status -2
... (unplug)
[94752.827336] usb 1-5: USB disconnect, device number 24
... (replug)
[94757.049106] usb 1-5: New USB device found, idVendor=2717, idProduct=3801, bcdDevice= 1.00
[94757.049112] usb 1-5: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[94757.049115] usb 1-5: Product: em006
[94757.049118] usb 1-5: Manufacturer: Xiaomi
[94757.049120] usb 1-5: SerialNumber: 2017

Signed-off-by: Harry Pan <harry.pan@intel.com>