### PR TITLE
lsusb.8.in: do not mention usb.ids

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,7 @@ lsusb.py: $(srcdir)/lsusb.py.in
 	chmod 755 $@
 
 lsusb.8: $(srcdir)/lsusb.8.in
-	sed 's|VERSION|$(VERSION)|g;s|@usbids@|$(datadir)/usb.ids|g' $< >$@
+	sed 's|VERSION|$(VERSION)|g' $< >$@
 
 usbhid-dump.8: $(srcdir)/usbhid-dump.8.in
 	sed 's|VERSION|$(VERSION)|g' $< >$@

--- a/lsusb.8.in
+++ b/lsusb.8.in
@@ -57,11 +57,6 @@ then exit successfully.
 .SH RETURN VALUE
 If the specified device is not found, a non-zero exit code is returned.
 
-.SH FILES
-.TP
-.B @usbids@
-A list of all known USB ID's (vendors, products, classes, subclasses and protocols).
-
 .SH SEE ALSO
 .BR lspci (8),
 .BR usbview (8).


### PR DESCRIPTION
The lsusb binary does not use the usb.ids file anymore, instead it uses
the udev hardware database. Mentionning usb.ids in lsusb(8) is therefore
very confusing for the users. This patch therefore drops that part.