### PR TITLE
usbhid-dump: Do not use rindex

### DIFF
--- a/usbhid-dump/src/usbhid-dump.c
+++ b/usbhid-dump/src/usbhid-dump.c
@@ -917,7 +917,7 @@ main(int argc, char **argv)
     /*
      * Extract program invocation name
      */
-    name = rindex(argv[0], '/');
+    name = strrchr(argv[0], '/');
     if (name == NULL)
         name = argv[0];
     else


### PR DESCRIPTION
rindex was removed in POSIX 2008. It is optionally unavailable with
uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>