### PR TITLE
lsusb: Fixed info read from sysfs when device is on a hub.

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -3694,6 +3694,8 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 
 	status = 1; /* 1 device not found, 0 device found */
 
+	lsusb_init_usb_tree();  /* sysfs will be ignored if this errors out */
+
 	num_devs = libusb_get_device_list(ctx, &list);
 	if (num_devs < 0)
 		goto error;
@@ -3702,7 +3704,6 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 		libusb_device *dev = list[i];
 		uint8_t bnum = libusb_get_bus_number(dev);
 		uint8_t dnum = libusb_get_device_address(dev);
-		uint8_t pnum = libusb_get_port_number(dev);
 
 		if ((busnum != -1 && busnum != bnum) ||
 		    (devnum != -1 && devnum != dnum))
@@ -3715,13 +3716,13 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 
 		vendor_len = get_vendor_string(vendor, sizeof(vendor), desc.idVendor);
 		if (vendor_len == 0)
-			read_sysfs_prop(vendor, sizeof(vendor), bnum, pnum,
+			read_sysfs_prop(vendor, sizeof(vendor), get_sysfs_name(bnum, dnum),
 					"manufacturer");
 
 		product_len = get_product_string(product, sizeof(product),
 				desc.idVendor, desc.idProduct);
 		if (product_len == 0)
-			read_sysfs_prop(product, sizeof(product), bnum, pnum,
+			read_sysfs_prop(product, sizeof(product), get_sysfs_name(bnum, dnum),
 					"product");
 
 		if (verblevel > 0)

--- a/lsusb.h
+++ b/lsusb.h
@@ -4,6 +4,8 @@
 #define _LSUSB_H
 
 extern int lsusb_t(void);
+extern int lsusb_init_usb_tree(void);
+extern char *get_sysfs_name(uint8_t bnum, uint8_t dnum);
 extern unsigned int verblevel;
 
 #endif

--- a/names.c
+++ b/names.c
@@ -32,7 +32,7 @@
 #define HASH2  0x02
 #define HASHSZ 512
 
-#define SYSFS_DEV_ATTR_PATH "/sys/bus/usb/devices/%d-%d/%s"
+#define SYSFS_DEV_ATTR_PATH "/sys/bus/usb/devices/%s/%s"
 
 static unsigned int hashnum(unsigned int num)
 {
@@ -391,7 +391,7 @@ static void print_tables(void)
 	}
 
 	printf("--------------------------------------------\n");
-	printf("\t\t Conutry Codes\n");
+	printf("\t\t Country Codes\n");
 	printf("--------------------------------------------\n");
 
 	for (i = 0; i < HASHSZ; i++) {
@@ -406,13 +406,12 @@ static void print_tables(void)
 }
 */
 
-int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname)
+int read_sysfs_prop(char *buf, size_t size, const char *sysfsname, char *propname)
 {
 	int n, fd;
 	char path[PATH_MAX];
 
-	buf[0] = '\0';
-	snprintf(path, sizeof(path), SYSFS_DEV_ATTR_PATH, bnum, pnum, propname);
+	snprintf(path, sizeof(path), SYSFS_DEV_ATTR_PATH, sysfsname, propname);
 	fd = open(path, O_RDONLY);
 
 	if (fd == -1)

--- a/names.h
+++ b/names.h
@@ -32,7 +32,7 @@ extern int get_product_string(char *buf, size_t size, uint16_t vid, uint16_t pid
 extern int get_class_string(char *buf, size_t size, uint8_t cls);
 extern int get_subclass_string(char *buf, size_t size, uint8_t cls, uint8_t subcls);
 
-extern int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname);
+extern int read_sysfs_prop(char *buf, size_t size, const char *sysfsname, char *propname);
 
 extern int names_init(void);
 extern void names_exit(void);


### PR DESCRIPTION
The wrong sysfs entry was read in such cases, displaying incorrect
information.

Note that this patch will only work for devices connected to a single
hub. It will still display the wrong information for devices connected
in a chain of two or more hubs.

This PR is mostly to show that there is a problem. This naive solution can
definitely be improved, but I'm not sure what the future-proof solution is.
I'm a bit surprised there isn't already an API to generate the correct file
name already.