### PR TITLE
lsusb.py: remove private paths for usb.ids

### DIFF
--- a/lsusb.py.in
+++ b/lsusb.py.in
@@ -30,8 +30,6 @@ prefix = "/sys/bus/usb/devices/"
 usbids = [
 	"@usbids@",
 	"/usr/share/usb.ids",
-	"/usr/share/libosinfo/usb.ids",
-	"/usr/share/kcmusb/usb.ids",
 ]
 cols = ("", "", "", "", "", "")
 


### PR DESCRIPTION
Do not look for usb.ids in the private paths of other software, as those locations are not public interface.

Signed-off-by: Pino Toscano <toscano.pino@tiscali.it>