### PR TITLE
bootstrap: change /bin/bash to /bin/sh

### DIFF
--- a/usbhid-dump/bootstrap
+++ b/usbhid-dump/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright (c) 2010 Nikolai Kondrashov
 #


### PR DESCRIPTION
Having `#!/bin/bash` requires that the user has `bash` installed on their system, which may not be the case. There is no reason to require this as the rest of `usbhid-dump/bootstrap` is compatible with `sh`.