### PR TITLE
Additional device classes for usb-devices script

### DIFF
--- a/usb-devices
+++ b/usb-devices
@@ -31,6 +31,9 @@ class_decode() {
 	"0d") echo "c-sec" ;;
 	"0e") echo "video" ;;
 	"0f") echo "perhc" ;;
+	"10") echo "av   " ;;
+	"11") echo "blbrd" ;;
+	"12") echo "bridg" ;;
 	"dc") echo "diagd" ;;
 	"e0") echo "wlcon" ;;
 	"ef") echo "misc " ;;


### PR DESCRIPTION
Several newer USB Device classes are not presently reported individually by
usb-devices, (They are reported as "unk. ").

This patch adds the following classes: 10h (USB Type-C combined Audio/Video
devices) 11h (USB billboard), 12h (USB Type-C Bridge).
As defined at [https://www.usb.org/defined-class-codes]

Signed-off-by: Rob Gill <rrobgill@protonmail.com>