### PR TITLE
usbmisc: don't take string's length at face value

### DIFF
--- a/usbmisc.c
+++ b/usbmisc.c
@@ -218,6 +218,9 @@ char *get_dev_string(libusb_device_handle *dev, uint8_t id)
 	if ((unsigned char)unicode_buf[0] < 2 || unicode_buf[1] != LIBUSB_DT_STRING)
 		return strdup("(error)");
 
+	/* Allow padding after string, but don't let strings claim to be longer. */
+	if ((unsigned char)unicode_buf[0] > ret) return strdup("(error)");
+
 	buf = usb_string_to_native(unicode_buf + 2,
 	                           ((unsigned char) unicode_buf[0] - 2) / 2);
 


### PR DESCRIPTION
This fixes a read out of bounds when a misbehaving USB device describes
its string as being longer than what it actually sends back. Noticed
this because libusb kept saying things like

```
  iManufacturer           1 YOURMOᱡ啰ｨ喷
  iProduct                1 YOURMOᱡ啰ｨ喷
  iSerial                 1 YOURMOᱡ啰ｨ喷
    ...
    iConfiguration          1 YOURMOᱡｩ喷
```

Notice how the same string changes? That's because it's actually only
six characters long; the rest is uninitialized stack memory.

Such malformed strings now print as (error).

Signed-off-by: Cliff L. Biffle <code@cliffle.com>