### PR TITLE
Fix bug in sysfs path construction and expand usage of sysfs queries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,7 @@ lsusb_SOURCES = \
 	desc-defs.c desc-defs.h \
 	desc-dump.c desc-dump.h \
 	names.c names.h \
+	sysfs.c sysfs.h \
 	usb-spec.h \
 	usbmisc.c usbmisc.h
 

--- a/lsusb.c
+++ b/lsusb.c
@@ -3703,7 +3703,8 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 		libusb_device *dev = list[i];
 		uint8_t bnum = libusb_get_bus_number(dev);
 		uint8_t dnum = libusb_get_device_address(dev);
-		uint8_t pnum = libusb_get_port_number(dev);
+		char sysfs_name[PATH_MAX];
+		get_sysfs_name(sysfs_name, sizeof(sysfs_name), dev);
 
 		if ((busnum != -1 && busnum != bnum) ||
 		    (devnum != -1 && devnum != dnum))
@@ -3716,13 +3717,13 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 
 		vendor_len = get_vendor_string(vendor, sizeof(vendor), desc.idVendor);
 		if (vendor_len == 0)
-			read_sysfs_prop(vendor, sizeof(vendor), bnum, pnum,
+			read_sysfs_prop(vendor, sizeof(vendor), sysfs_name,
 					"manufacturer");
 
 		product_len = get_product_string(product, sizeof(product),
 				desc.idVendor, desc.idProduct);
 		if (product_len == 0)
-			read_sysfs_prop(product, sizeof(product), bnum, pnum,
+			read_sysfs_prop(product, sizeof(product), sysfs_name,
 					"product");
 
 		if (verblevel > 0)

--- a/lsusb.c
+++ b/lsusb.c
@@ -27,6 +27,7 @@
 
 #include "lsusb.h"
 #include "names.h"
+#include "sysfs.h"
 #include "usbmisc.h"
 #include "desc-defs.h"
 #include "desc-dump.h"

--- a/lsusb.c
+++ b/lsusb.c
@@ -3663,6 +3663,38 @@ static void dumpdev(libusb_device *dev)
 
 /* ---------------------------------------------------------------------- */
 
+/*
+ * Attempt to get friendly vendor and product names from the udev hwdb. If
+ * either or both are not present, instead populate those from the device's
+ * own string descriptors.
+ */
+static void get_vendor_product_with_fallback(char *vendor, int vendor_len,
+					     char *product, int product_len,
+					     libusb_device *dev)
+{
+	struct libusb_device_descriptor desc;
+	char sysfs_name[PATH_MAX];
+	bool have_vendor, have_product;
+
+	libusb_get_device_descriptor(dev, &desc);
+
+	have_vendor = !!get_vendor_string(vendor, vendor_len, desc.idVendor);
+	have_product = !!get_product_string(product, product_len,
+			desc.idVendor, desc.idProduct);
+
+	if (have_vendor && have_product)
+		return;
+
+	if (get_sysfs_name(sysfs_name, sizeof(sysfs_name), dev) >= 0) {
+		if (!have_vendor)
+			read_sysfs_prop(vendor, vendor_len, sysfs_name,
+					"manufacturer");
+		if (!have_product)
+			read_sysfs_prop(product, product_len, sysfs_name,
+					"product");
+	}
+}
+
 static int dump_one_device(libusb_context *ctx, const char *path)
 {
 	libusb_device *dev;
@@ -3675,8 +3707,8 @@ static int dump_one_device(libusb_context *ctx, const char *path)
 		return 1;
 	}
 	libusb_get_device_descriptor(dev, &desc);
-	get_vendor_string(vendor, sizeof(vendor), desc.idVendor);
-	get_product_string(product, sizeof(product), desc.idVendor, desc.idProduct);
+	get_vendor_product_with_fallback(vendor, sizeof(vendor),
+			product, sizeof(product), dev);
 	printf("Device: ID %04x:%04x %s %s\n", desc.idVendor,
 					       desc.idProduct,
 					       vendor,
@@ -3691,7 +3723,7 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 	struct libusb_device_descriptor desc;
 	char vendor[128], product[128];
 	int status;
-	ssize_t num_devs, i, vendor_len, product_len;
+	ssize_t num_devs, i;
 
 	status = 1; /* 1 device not found, 0 device found */
 
@@ -3703,8 +3735,6 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 		libusb_device *dev = list[i];
 		uint8_t bnum = libusb_get_bus_number(dev);
 		uint8_t dnum = libusb_get_device_address(dev);
-		char sysfs_name[PATH_MAX];
-		get_sysfs_name(sysfs_name, sizeof(sysfs_name), dev);
 
 		if ((busnum != -1 && busnum != bnum) ||
 		    (devnum != -1 && devnum != dnum))
@@ -3715,16 +3745,8 @@ static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendori
 			continue;
 		status = 0;
 
-		vendor_len = get_vendor_string(vendor, sizeof(vendor), desc.idVendor);
-		if (vendor_len == 0)
-			read_sysfs_prop(vendor, sizeof(vendor), sysfs_name,
-					"manufacturer");
-
-		product_len = get_product_string(product, sizeof(product),
-				desc.idVendor, desc.idProduct);
-		if (product_len == 0)
-			read_sysfs_prop(product, sizeof(product), sysfs_name,
-					"product");
+		get_vendor_product_with_fallback(vendor, sizeof(vendor),
+				product, sizeof(product), dev);
 
 		if (verblevel > 0)
 			printf("\n");

--- a/names.c
+++ b/names.c
@@ -20,7 +20,6 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
-#include <linux/limits.h>
 
 #include <libudev.h>
 
@@ -31,8 +30,6 @@
 #define HASH1  0x10
 #define HASH2  0x02
 #define HASHSZ 512
-
-#define SYSFS_DEV_ATTR_PATH "/sys/bus/usb/devices/%d-%d/%s"
 
 static unsigned int hashnum(unsigned int num)
 {
@@ -405,27 +402,6 @@ static void print_tables(void)
 	printf("--------------------------------------------\n");
 }
 */
-
-int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname)
-{
-	int n, fd;
-	char path[PATH_MAX];
-
-	buf[0] = '\0';
-	snprintf(path, sizeof(path), SYSFS_DEV_ATTR_PATH, bnum, pnum, propname);
-	fd = open(path, O_RDONLY);
-
-	if (fd == -1)
-		return 0;
-
-	n = read(fd, buf, size);
-
-	if (n > 0)
-		buf[n-1] = '\0';  // Turn newline into null terminator
-
-	close(fd);
-	return n;
-}
 
 int names_init(void)
 {

--- a/names.h
+++ b/names.h
@@ -32,8 +32,6 @@ extern int get_product_string(char *buf, size_t size, uint16_t vid, uint16_t pid
 extern int get_class_string(char *buf, size_t size, uint8_t cls);
 extern int get_subclass_string(char *buf, size_t size, uint8_t cls, uint8_t subcls);
 
-extern int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname);
-
 extern int names_init(void);
 extern void names_exit(void);
 

--- a/sysfs.c
+++ b/sysfs.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Helpers for querying USB properties from sysfs
+ */
+
+#include <stdint.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <linux/limits.h>
+
+#include "sysfs.h"
+
+#define SYSFS_DEV_ATTR_PATH "/sys/bus/usb/devices/%d-%d/%s"
+
+int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname)
+{
+	int n, fd;
+	char path[PATH_MAX];
+
+	buf[0] = '\0';
+	snprintf(path, sizeof(path), SYSFS_DEV_ATTR_PATH, bnum, pnum, propname);
+	fd = open(path, O_RDONLY);
+
+	if (fd == -1)
+		return 0;
+
+	n = read(fd, buf, size);
+
+	if (n > 0)
+		buf[n-1] = '\0';  // Turn newline into null terminator
+
+	close(fd);
+	return n;
+}

--- a/sysfs.c
+++ b/sysfs.c
@@ -10,17 +10,49 @@
 #include <stdio.h>
 #include <linux/limits.h>
 
+#include <libusb.h>
+
 #include "sysfs.h"
 
-#define SYSFS_DEV_ATTR_PATH "/sys/bus/usb/devices/%d-%d/%s"
+/*
+ * The documentation of libusb_get_port_numbers() says "As per the USB 3.0
+ * specs, the current maximum limit for the depth is 7."
+ */
+#define USB_MAX_DEPTH 7
 
-int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname)
+#define SYSFS_DEV_ATTR_PATH "/sys/bus/usb/devices/%s/%s"
+
+int get_sysfs_name(char *buf, size_t size, libusb_device *dev)
+{
+	int len = 0;
+	uint8_t bnum = libusb_get_bus_number(dev);
+	uint8_t pnums[USB_MAX_DEPTH];
+	int num_pnums;
+
+	buf[0] = '\0';
+
+	num_pnums = libusb_get_port_numbers(dev, pnums, sizeof(pnums));
+	if (num_pnums == LIBUSB_ERROR_OVERFLOW) {
+		return -1;
+	} else if (num_pnums == 0) {
+		/* Special-case root devices */
+		return snprintf(buf, size, "usb%d", bnum);
+	}
+
+	len += snprintf(buf, size, "%d-", bnum);
+	for (int i = 0; i < num_pnums; i++)
+		len += snprintf(buf + len, size - len, i ? ".%d" : "%d", pnums[i]);
+
+	return len;
+}
+
+int read_sysfs_prop(char *buf, size_t size, char *sysfs_name, char *propname)
 {
 	int n, fd;
 	char path[PATH_MAX];
 
 	buf[0] = '\0';
-	snprintf(path, sizeof(path), SYSFS_DEV_ATTR_PATH, bnum, pnum, propname);
+	snprintf(path, sizeof(path), SYSFS_DEV_ATTR_PATH, sysfs_name, propname);
 	fd = open(path, O_RDONLY);
 
 	if (fd == -1)

--- a/sysfs.h
+++ b/sysfs.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Helpers for querying USB properties from sysfs
+ */
+
+#ifndef _SYSFS_H
+#define _SYSFS_H
+/* ---------------------------------------------------------------------- */
+
+extern int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname);
+
+/* ---------------------------------------------------------------------- */
+#endif /* _SYSFS_H */

--- a/sysfs.h
+++ b/sysfs.h
@@ -7,7 +7,8 @@
 #define _SYSFS_H
 /* ---------------------------------------------------------------------- */
 
-extern int read_sysfs_prop(char *buf, size_t size, uint8_t bnum, uint8_t pnum, char *propname);
+int get_sysfs_name(char *buf, size_t size, libusb_device *dev);
+extern int read_sysfs_prop(char *buf, size_t size, char *sysfs_name, char *propname);
 
 /* ---------------------------------------------------------------------- */
 #endif /* _SYSFS_H */


### PR DESCRIPTION
First off, I want to acknowledge that this pull request includes a fix for the same issue #108 fixes. I didn't notice that PR until I was almost done with this one, but I do think that the additional code cleanup and refactoring I did makes this PR worth reviewing, even ignoring its other changes.

So what are those other fixes? The commit messages have details, but to summarize they are
1. Ensure that the existing logic to fall back on device-reported vendor/product names from sysfs is consistently applied. Currently, it's not used at all when listing only a single device using `-D`.
2. When running with `-v`, fetch strings for iManufacturer, iProduct, and iSerial from sysfs instead of from libusb. This allows these values to be populated even when we don't have permission to open the device.
3. General code cleanup by moving sysfs-related functions to their own file instead of mixing them in with hwdb-related ones.

Edit: I just noticed that #103 is ALSO a fix for the sysfs path issue. That fix is implemented very differently from mine but also makes sense.