### PR TITLE
usbhid-dump: Put back autoconf check for libusb_set_option()

### DIFF
--- a/usbhid-dump/configure.ac
+++ b/usbhid-dump/configure.ac
@@ -67,6 +67,7 @@ fi
 #
 # Checks for library functions.
 #
+AC_CHECK_FUNCS(libusb_set_option)
 
 #
 # Output


### PR DESCRIPTION
Because usbhid-dump/src/usbhid-dump.c checks for HAVE_LIBUSB_SET_OPTION

It fell out in commit e0525b6

Signed-off-by: Tormod Volden <debian.tormod@gmail.com>