### PR TITLE
lsusb(8): mention the udev's hardware database

### DIFF
--- a/lsusb.8.in
+++ b/lsusb.8.in
@@ -12,7 +12,8 @@ lsusb \- list USB devices
 .SH DESCRIPTION
 .B lsusb
 is a utility for displaying information about USB buses in the system and
-the devices connected to them.
+the devices connected to them. It uses udev's hardware database to
+associate a full human-readable name to the vendor ID and the product ID.
 
 .SH OPTIONS
 .TP


### PR DESCRIPTION
Despite the switch to the udev's hardware database being a few years
old, users are still confused when they update usb.ids on their system
and see no effects. This patch therefore updates the lsusb(8) manpage to
mention it.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>