### PR TITLE
lsusb-t: Add lower bound checks in read_sysfs_file_string

### DIFF
--- a/lsusb-t.c
+++ b/lsusb-t.c
@@ -241,11 +241,11 @@ static void read_sysfs_file_string(const char *d_name, const char *file, char *b
 	if (r > 0 && r < len) {
 		buf[r] = '\0';
 		r--;
-		while (buf[r] == '\n') {
+		while (r >= 0 && buf[r] == '\n') {
 			buf[r] = '\0';
 			r--;
 		}
-		while (r) {
+		while (r >= 0) {
 			if (buf[r] == '\n')
 				buf[r] = ' ';
 			r--;


### PR DESCRIPTION
I have a USB device that returns "\n\n" in manufacturer field which
makes newline cleanup in read_sysfs_file_string result in out-of-bound
access.

Fix this by adding lower bound checks in the loops.