### PR TITLE
lsusb.c: fix leak in dump_printer_device

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -2423,6 +2423,7 @@ static void dump_printer_device(libusb_device_handle *dev,
 			else if ((caps & 0x60) == 0x60)
 				printf(" Negotiable-Auth");
 			printf("\n");
+			free(uuid);
 			break;
 		}
 		default:


### PR DESCRIPTION
Allocation made by `get_dev_string` was not freed.