### PR TITLE
desc-defs.c: fix possible out-of-bound read

### DIFF
--- a/desc-defs.c
+++ b/desc-defs.c
@@ -966,7 +966,7 @@ static void desc_snowflake_dump_uac1_as_interface_wformattag(
 
 	/* Format codes are 0xTNNN, where T=Type prefix, NNN = format code. */
 
-	if (value <= ((UAC_FORMAT_TYPE_I << 12) +
+	if (value < ((UAC_FORMAT_TYPE_I << 12) +
 	              ARRAY_LEN(audio_data_format_type_i))) {
 		format_string = audio_data_format_type_i[value];
 


### PR DESCRIPTION
Found by static analysis:

Expression `(UAC_FORMAT_TYPE_I << 12) + ARRAY_LEN(audio_data_format_type_i)`
evaluates to 6 which is the length of the `audio_data_format_type_i` array.
Therefore, if value is set to 6, the condition evaluates to true and
ouf-of-bound read could occur.