### PR TITLE
Build as much as possible on non-Linux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,10 @@
 SUBDIRS = \
 	usbhid-dump
 
+if HAVE_GNULD
 AM_LDFLAGS = \
 	-Wl,--as-needed
+endif
 
 data_DATA =
 

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,20 @@ PKG_CHECK_MODULES(UDEV, libudev >= 196,
 		  [AC_DEFINE([HAVE_UDEV], [1], [Use UDEV])],
 		  [true])
 
+AC_MSG_CHECKING(for GNU ld)
+ac_prog=ld
+if test "$GCC" = yes; then
+       ac_prog=`$CC -print-prog-name=ld`
+fi
+case `"$ac_prog" -V 2>&1 < /dev/null` in
+      *GNU*)
+          GNULD=yes;;
+      *)
+          GNULD=no;;
+esac
+AC_MSG_RESULT($GNULD)
+AM_CONDITIONAL([HAVE_GNULD], [test "$GNULD" = yes])
+
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
 	Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,9 @@ AC_CHECK_FUNCS([nl_langinfo iconv])
 
 PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.14)
 
-PKG_CHECK_MODULES(UDEV, libudev >= 196)
+PKG_CHECK_MODULES(UDEV, libudev >= 196,
+		  [AC_DEFINE([HAVE_UDEV], [1], [Use UDEV])],
+		  [true])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([

--- a/lsusb-t.c
+++ b/lsusb-t.c
@@ -19,6 +19,8 @@
 #define MY_PATH_MAX 4096
 #define MY_PARAM_MAX 64
 
+#ifdef __linux__
+
 struct usbinterface {
 	struct list_head list;
 	struct usbinterface *next;
@@ -728,3 +730,11 @@ int lsusb_t(void)
 		perror(sys_bus_usb_devices);
 	return sbud == NULL;
 }
+
+#else
+int lsusb_t(void)
+{
+	fprintf(stderr, "lsusb -t is only supported on Linux\n");
+	return 1;
+}
+#endif /* __linux__ */

--- a/lsusb.c
+++ b/lsusb.c
@@ -3711,6 +3711,7 @@ static void get_vendor_product_with_fallback(char *vendor, int vendor_len,
 
 static int dump_one_device(libusb_context *ctx, const char *path)
 {
+#if __linux__
 	libusb_device *dev;
 	struct libusb_device_descriptor desc;
 	char vendor[128], product[128];
@@ -3729,6 +3730,10 @@ static int dump_one_device(libusb_context *ctx, const char *path)
 					       product);
 	dumpdev(dev);
 	return 0;
+#else
+	fprintf(stderr, "Only supported on Linux\n");
+	return 1;
+#endif /* __linux__ */
 }
 
 static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendorid, int productid)

--- a/names.c
+++ b/names.c
@@ -21,7 +21,9 @@
 #include <stdio.h>
 #include <ctype.h>
 
-#include <libudev.h>
+#ifdef HAVE_UDEV
+# include <libudev.h>
+#endif
 
 #include "usb-spec.h"
 #include "names.h"
@@ -43,8 +45,10 @@ static unsigned int hashnum(unsigned int num)
 
 /* ---------------------------------------------------------------------- */
 
+#ifdef HAVE_UDEV
 static struct udev *udev = NULL;
 static struct udev_hwdb *hwdb = NULL;
+#endif
 static struct audioterminal *audioterminals_hash[HASHSZ] = { NULL, };
 static struct videoterminal *videoterminals_hash[HASHSZ] = { NULL, };
 static struct genericstrtable *hiddescriptors_hash[HASHSZ] = { NULL, };
@@ -113,9 +117,11 @@ static const char *hwdb_get(const char *modalias, const char *key)
 {
 	struct udev_list_entry *entry;
 
+#ifdef HAVE_UDEV
 	udev_list_entry_foreach(entry, udev_hwdb_get_properties_list_entry(hwdb, modalias, 0))
 		if (strcmp(udev_list_entry_get_name(entry), key) == 0)
 			return udev_list_entry_get_value(entry);
+#endif
 
 	return NULL;
 }
@@ -407,6 +413,7 @@ int names_init(void)
 {
 	int r;
 
+#ifdef HAVE_UDEV
 	udev = udev_new();
 	if (!udev)
 		r = -1;
@@ -415,6 +422,7 @@ int names_init(void)
 		if (!hwdb)
 			r = -1;
 	}
+#endif
 
 	r = hash_tables();
 
@@ -423,6 +431,8 @@ int names_init(void)
 
 void names_exit(void)
 {
+#ifdef HAVE_UDEV
 	hwdb = udev_hwdb_unref(hwdb);
 	udev = udev_unref(udev);
+#endif
 }

--- a/sysfs.c
+++ b/sysfs.c
@@ -12,10 +12,11 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <linux/limits.h>
-
 #include <libusb.h>
 
+#ifdef __linux__
+
+#include <linux/limits.h>
 #include "sysfs.h"
 
 /*
@@ -70,3 +71,15 @@ int read_sysfs_prop(char *buf, size_t size, char *sysfs_name, char *propname)
 	close(fd);
 	return n;
 }
+
+#else
+int get_sysfs_name(char *buf, size_t size, libusb_device *dev)
+{
+	return -1;
+}
+
+int read_sysfs_prop(char *buf, size_t size, char *sysfs_name, char *propname)
+{
+	return -1;
+}
+#endif /* __linux__ */

--- a/usbhid-dump/configure.ac
+++ b/usbhid-dump/configure.ac
@@ -67,7 +67,7 @@ fi
 #
 # Checks for library functions.
 #
-AC_CHECK_FUNCS(libusb_set_option)
+AC_CHECK_FUNCS(libusb_set_option sigaction)
 
 #
 # Output

--- a/usbhid-dump/src/usbhid-dump.c
+++ b/usbhid-dump/src/usbhid-dump.c
@@ -912,7 +912,9 @@ main(int argc, char **argv)
     bool                dump_stream     = false;
     unsigned int        stream_timeout  = 60000;
 
+#ifdef HAVE_SIGACTION
     struct sigaction    sa;
+#endif
 
     /*
      * Extract program invocation name
@@ -1003,6 +1005,7 @@ main(int argc, char **argv)
     if (optind < argc)
         USAGE_ERROR("Positional arguments are not accepted");
 
+#ifdef HAVE_SIGACTION
     /*
      * Setup signal handlers
      */
@@ -1035,6 +1038,7 @@ main(int argc, char **argv)
     sigaction(SIGUSR1, &sa, NULL);
     sa.sa_handler = stream_resume_sighandler;
     sigaction(SIGUSR2, &sa, NULL);
+#endif /* HAVE_SIGACTION */
 
     /* Make stdout buffered - we will flush it explicitly */
     setbuf(stdout, NULL);
@@ -1043,6 +1047,7 @@ main(int argc, char **argv)
     result = run(dump_descriptor, dump_stream, stream_timeout,
                  bus_num, dev_addr, vid, pid, iface_num);
 
+#ifdef HAVE_SIGACTION
     /*
      * Restore signal handlers
      */
@@ -1061,6 +1066,7 @@ main(int argc, char **argv)
     if (exit_signum != 0)
         raise(exit_signum);
 
+#endif /* HAVE_SIGACTION */
     return result;
 }
 

--- a/usbmisc.c
+++ b/usbmisc.c
@@ -25,6 +25,8 @@
 
 #include "usbmisc.h"
 
+#ifdef __linux__
+
 /* ---------------------------------------------------------------------- */
 
 static const char *devbususb = "/dev/bus/usb";
@@ -140,6 +142,8 @@ libusb_device *get_usb_device(libusb_context *ctx, const char *path)
 	libusb_free_device_list(list, 0);
 	return dev;
 }
+
+#endif /* __linux__ */
 
 static char *get_dev_string_ascii(libusb_device_handle *dev, size_t size,
                                   uint8_t id)

--- a/usbreset.c
+++ b/usbreset.c
@@ -14,6 +14,9 @@
 #include <ctype.h>
 #include <limits.h>
 #include <dirent.h>
+
+#ifdef __linux__
+
 #include <sys/ioctl.h>
 
 #include <linux/usbdevice_fs.h>
@@ -189,3 +192,11 @@ int main(int argc, char **argv)
 	reset_device(dev);
 	return 0;
 }
+
+#else
+int main(int argc, char **argv)
+{
+	fprintf(stderr, "Only supported on Linux\n");
+	exit(1);
+}
+#endif /* __linux__ */


### PR DESCRIPTION
Disables the Linux-only functionality (udev, sysfs lookups) but otherwise works fairly well on macOS and Windows (MinGW).

I have the suspicion that platform portability is not on the top of the list for usbutils (especially after version 007) but please consider this, or parts of it. Any review and comments are welcome.

This might get into for instance Homebrew https://github.com/Homebrew/homebrew-core/pull/89341, and would be great for cross-platform USB development (e.g. libusb debugging).