### PR TITLE
lsusb-t: Fix recursive sorting on child devices.

### DIFF
--- a/lsusb-t.c
+++ b/lsusb-t.c
@@ -632,6 +632,7 @@ static void sort_dev_siblings(struct usbdevice **d)
 		pp = d;
 		swapped = 0;
 		while (p->next) {
+			sort_dev_siblings(&p->next);
 			if (p->portnum > p->next->portnum) {
 				t = p->next;
 				p->next = t->next;


### PR DESCRIPTION
When sorting child devices, only the first child is recursed into. This fix allows all child devices to be recursed into.

Signed-off-by: Tan Li Boon <liboon.tan@mujin.co.jp>