### PR TITLE
lsusb: Add function that sorts the output by device ID.

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -3634,10 +3634,10 @@ static int dump_one_device(libusb_context *ctx, const char *path)
 	return 0;
 }
 
-void sort_device_list(libusb_device **list, ssize_t num_devs)
+static void sort_device_list(libusb_device **list, ssize_t num_devs)
 {
 	struct libusb_device *dev, *dev_next;
-	uint8_t bnum, bnum_next, dnum, dnum_next;
+	int bnum, bnum_next, dnum, dnum_next;
 	ssize_t i;
 	int sorted;
 	sorted = 0;
@@ -3653,8 +3653,10 @@ void sort_device_list(libusb_device **list, ssize_t num_devs)
 				dev_next = list[i + 1];
 				bnum_next = libusb_get_bus_number(dev_next);
 				dnum_next = libusb_get_device_address(dev_next);
+			} else {
+				break;
 			}
-			if (bnum == bnum_next && dnum > dnum_next) {
+			if ((bnum == bnum_next && dnum > dnum_next) || bnum > bnum_next) {
 				list[i] = dev_next;
 				list[i + 1] = dev;
 				sorted = 0;

--- a/lsusb.c
+++ b/lsusb.c
@@ -3643,19 +3643,13 @@ static void sort_device_list(libusb_device **list, ssize_t num_devs)
 	sorted = 0;
 	do {
 		sorted = 1;
-		for (i = 0; i < num_devs; ++i) {
+		for (i = 0; i < num_devs - 1; ++i) {
 			dev = list[i];
+			dev_next = list[i + 1];
 			bnum = libusb_get_bus_number(dev);
 			dnum = libusb_get_device_address(dev);
-			bnum_next = -1;
-			dnum_next = -1;
-			if (i + 1 < num_devs) {
-				dev_next = list[i + 1];
-				bnum_next = libusb_get_bus_number(dev_next);
-				dnum_next = libusb_get_device_address(dev_next);
-			} else {
-				break;
-			}
+			bnum_next = libusb_get_bus_number(dev_next);
+			dnum_next = libusb_get_device_address(dev_next);
 			if ((bnum == bnum_next && dnum > dnum_next) || bnum > bnum_next) {
 				list[i] = dev_next;
 				list[i + 1] = dev;


### PR DESCRIPTION
On the master branch, device IDs are unsorted. An example from my laptop:

```
Bus 004 Device 003: ID 17ef:a393 Lenovo USB3.1 Hub
Bus 004 Device 004: ID 17ef:a387 Lenovo USB-C Dock Ethernet
Bus 004 Device 002: ID 17ef:a391 Lenovo USB3.1 Hub
Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 003 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 002 Device 002: ID 0bda:0328 Realtek Semiconductor Corp. USB3.0-CRW
Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 001 Device 008: ID 06cb:009a Synaptics, Inc. Metallica MIS Touch Fingerprint Reader
Bus 001 Device 006: ID 5986:2115 Acer, Inc Integrated Camera
Bus 001 Device 029: ID 067b:2303 Prolific Technology, Inc. PL2303 Serial Port / Mobile Action MA-8910P
Bus 001 Device 032: ID 045e:0823 Microsoft Corp. Classic IntelliMouse
Bus 001 Device 031: ID 17ef:a396 Lenovo ThinkPad USB-C Dock Gen2 USB Audio
Bus 001 Device 030: ID 04b4:521a Cypress Semiconductor Corp. USB-I2C Bridge
Bus 001 Device 028: ID 17ef:a395 Lenovo USB2.0 Hub
Bus 001 Device 027: ID 2be8:0002 ARCHISS PTR87 ARCHISS PTR87
Bus 001 Device 026: ID 17ef:a394 Lenovo USB2.0 Hub
Bus 001 Device 025: ID 17ef:a392 Lenovo USB2.0 Hub
Bus 001 Device 002: ID 046d:c52b Logitech, Inc. Unifying Receiver
Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
```

This patch introduces a function that sorts the device IDs by bus:

```
Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 004 Device 002: ID 17ef:a391 Lenovo USB3.1 Hub
Bus 004 Device 003: ID 17ef:a393 Lenovo USB3.1 Hub
Bus 004 Device 004: ID 17ef:a387 Lenovo USB-C Dock Ethernet
Bus 003 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 002 Device 002: ID 0bda:0328 Realtek Semiconductor Corp. USB3.0-CRW
Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
Bus 001 Device 002: ID 046d:c52b Logitech, Inc. Unifying Receiver
Bus 001 Device 006: ID 5986:2115 Acer, Inc Integrated Camera
Bus 001 Device 008: ID 06cb:009a Synaptics, Inc. Metallica MIS Touch Fingerprint Reader
Bus 001 Device 025: ID 17ef:a392 Lenovo USB2.0 Hub
Bus 001 Device 026: ID 17ef:a394 Lenovo USB2.0 Hub
Bus 001 Device 027: ID 2be8:0002 ARCHISS PTR87 ARCHISS PTR87
Bus 001 Device 028: ID 17ef:a395 Lenovo USB2.0 Hub
Bus 001 Device 029: ID 067b:2303 Prolific Technology, Inc. PL2303 Serial Port / Mobile Action MA-8910P
Bus 001 Device 030: ID 04b4:521a Cypress Semiconductor Corp. USB-I2C Bridge
Bus 001 Device 031: ID 17ef:a396 Lenovo ThinkPad USB-C Dock Gen2 USB Audio
```
Signed-off-by: Tan Li Boon <liboon.tan@mujin.co.jp>

Notes: I'm not really sure if this would be a thing that anyone besides me really 'wants'... Also C is not my primary language, I'm more used to working in C++, so please scrutinize my conventions.