### PR TITLE
Fix an runtime error reported by undefind sanitizer

### DIFF
--- a/names.c
+++ b/names.c
@@ -33,7 +33,7 @@
 
 static unsigned int hashnum(unsigned int num)
 {
-	unsigned int mask1 = HASH1 << 27, mask2 = HASH2 << 27;
+	unsigned int mask1 = (unsigned int)HASH1 << 27, mask2 = (unsigned int)HASH2 << 27;
 
 	for (; mask1 >= HASH1; mask1 >>= 1, mask2 >>= 1)
 		if (num & mask1)


### PR DESCRIPTION
Fix the following error when compiling with undefined sanitizer:

./lsusb
names.c:36:29: runtime error: left shift of 16 by 27 places cannot be represented in type 'int'

Signed-off-by: Han Han <hhan@redhat.com>