### PR TITLE
lsusb: fix incorrect variable type and unalignments when dumping hid …

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -2463,8 +2463,8 @@ static void dump_hid_device(libusb_device_handle *dev,
 		return;
 
 	if (!dev) {
-		printf("         Report Descriptors: \n"
-		       "           ** UNAVAILABLE **\n");
+		printf("          Report Descriptors: \n"
+		       "            ** UNAVAILABLE **\n");
 		return;
 	}
 
@@ -2503,8 +2503,8 @@ static void dump_hid_device(libusb_device_handle *dev,
 			/* recent Linuxes require claim() for RECIP_INTERFACE,
 			 * so "rmmod hid" will often make these available.
 			 */
-			printf("         Report Descriptors: \n"
-			       "           ** UNAVAILABLE **\n");
+			printf("          Report Descriptors: \n"
+			       "            ** UNAVAILABLE **\n");
 		}
 	}
 }

--- a/lsusb.c
+++ b/lsusb.c
@@ -2438,8 +2438,7 @@ static void dump_hid_device(libusb_device_handle *dev,
 			    const struct libusb_interface_descriptor *interface,
 			    const unsigned char *buf)
 {
-	unsigned int i, len;
-	unsigned int n;
+	int i, len;
 	unsigned char dbuf[8192];
 
 	if (buf[1] != LIBUSB_DT_HID)
@@ -2474,13 +2473,13 @@ static void dump_hid_device(libusb_device_handle *dev,
 		if (buf[6+3*i] != LIBUSB_DT_REPORT)
 			continue;
 		len = buf[7+3*i] | (buf[8+3*i] << 8);
-		if (len > (unsigned int)sizeof(dbuf)) {
+		if (len > (int)sizeof(dbuf)) {
 			printf("report descriptor too long\n");
 			continue;
 		}
 		if (libusb_claim_interface(dev, interface->bInterfaceNumber) == 0) {
 			int retries = 4;
-			n = 0;
+			int n = 0;
 			while (n < len && retries--)
 				n = usb_control_msg(dev,
 					 LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_STANDARD
@@ -2495,6 +2494,9 @@ static void dump_hid_device(libusb_device_handle *dev,
 				if (n < len)
 					printf("          Warning: incomplete report descriptor\n");
 				dump_report_desc(dbuf, n);
+			} else {
+				printf("          Warning: can't get report descriptor, %s\n",
+						  libusb_error_name(n));
 			}
 			libusb_release_interface(dev, interface->bInterfaceNumber);
 		} else {


### PR DESCRIPTION
First issue, I found there is a weird line:
<img width="558" alt="HID Device Descriptor" src="https://user-images.githubusercontent.com/36058930/207830509-36c5e76c-51ba-4b8c-9646-e01db22b4e94.png">
This because an unsigned int type is used to hold a potential negative value. In order to fix it, I change some variable type to int. I think int type is also safe to hold the values without overflow. After fixing it:
<img width="578" alt="bLength" src="https://user-images.githubusercontent.com/36058930/207832427-06ecd419-7243-4c37-b27a-fcc242dd7530.png">


Second issue, an unalignment for string "Report Descriptors":
<img width="710" alt="HID Device Descriptor" src="https://user-images.githubusercontent.com/36058930/207832173-0587cfce-dd13-4473-87ac-b58d6501a9e2.png">
After fixing it:
<img width="400" alt="HID Device Descriptor" src="https://user-images.githubusercontent.com/36058930/207832324-f8956382-eba3-4d54-b757-f645354781b6.png">
