### PR TITLE
Generate usbutils.pc pkgconfig file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,6 +60,8 @@ EXTRA_DIST = \
 	LICENSES/GPL-2.0-only.txt \
 	LICENSES/GPL-3.0-only.txt
 
+pkgconfig_DATA = usbutils.pc
+
 lsusb.py: $(srcdir)/lsusb.py.in
 	sed 's|VERSION|$(VERSION)|g;s|@usbids@|$(datadir)/usb.ids|g' $< >$@
 	chmod 755 $@

--- a/configure.ac
+++ b/configure.ac
@@ -15,12 +15,15 @@ AC_SYS_LARGEFILE
 AC_CHECK_HEADERS([byteswap.h])
 AC_CHECK_FUNCS([nl_langinfo iconv])
 
+PKG_INSTALLDIR
+
 PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.14)
 
 PKG_CHECK_MODULES(UDEV, libudev >= 196)
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
+	usbutils.pc
 	Makefile
 ])
 AC_CONFIG_SUBDIRS([usbhid-dump])
@@ -33,6 +36,7 @@ AC_MSG_RESULT([
 	prefix:                 ${prefix}
 	datarootdir:            ${datarootdir}
 	datadir:                ${datadir}
+	pkgconfigdir:		${pkgconfigdir}
 	mandir:                 ${mandir}
 
 	usb.ids:                ${datadir}/usb.ids

--- a/usbutils.pc.in
+++ b/usbutils.pc.in
@@ -1,0 +1,18 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=@prefix@/lib64
+includedir=@prefix@/include
+usbids=@datadir@/usb.ids
+
+Name: @PACKAGE_NAME@
+Description: usbutils    This is a collection of USB tools for use on Linux and BSD systems\
+ to query what type of USB devices are connected to the system. This is to be run on a USB host\
+  (i.e. a machine you plug USB devices into), not on a USB device (i.e. a device you plug into a USB host.)
+
+Version: @VERSION@
+URL: https://github.com/gregkh/usbutils
+Requires: libusb-1.0 >= 1.0.14  libudev >= 196
+Conflicts:
+Libs: -L@prefix@/lib64
+Libs.private: @LIBUSB_LIBS@ @UDEV_LIBS@
+Cflags: @CFLAGS@ @LIBUSB_CFLAGS@ @UDEV_CFLAGS@


### PR DESCRIPTION
Add .pc.in file as proposed in #153.

I'm not really familiar with pkgconfig so someone should maybe have a closer look.
I'm also not sure about the `usb.ids`. `usb.ids` are mentioned in configure.ac but the file seems neither be installed nor generated.

If you want some modifications to this PR just let me know.