### PR TITLE
Include "negotiated speed" in device dump

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -273,6 +273,7 @@ static void dump_device(
 	char cls[128], subcls[128], proto[128];
 	char mfg[128] = {0}, prod[128] = {0}, serial[128] = {0};
 	char sysfs_name[PATH_MAX];
+	const char * negotiated_speed;
 
 	get_vendor_product_with_fallback(vendor, sizeof(vendor),
 			product, sizeof(product), dev);
@@ -287,6 +288,29 @@ static void dump_device(
 		read_sysfs_prop(prod, sizeof(prod), sysfs_name, "product");
 		read_sysfs_prop(serial, sizeof(serial), sysfs_name, "serial");
 	}
+
+	negotiated_speed = NULL;
+	switch (libusb_get_device_speed(dev)) {
+		case LIBUSB_SPEED_LOW:
+			negotiated_speed = "Low Speed (1Mbps)";
+			break;
+		case LIBUSB_SPEED_FULL:
+			negotiated_speed = "Full Speed (12Mbps)";
+			break;
+		case LIBUSB_SPEED_HIGH:
+			negotiated_speed = "High Speed (480Mbps)";
+			break;
+		case LIBUSB_SPEED_SUPER:
+			negotiated_speed = "SuperSpeed (5Gbps)";
+			break;
+		case LIBUSB_SPEED_SUPER_PLUS:
+			negotiated_speed = "SuperSpeed+ (10Gbps)";
+			break;
+		default:
+			negotiated_speed = "Unknown";
+			break;
+	}
+	printf("Negotiated speed :        %s\n", negotiated_speed);
 
 	printf("Device Descriptor:\n"
 	       "  bLength             %5u\n"


### PR DESCRIPTION
It used to be simple to make sure a device connection was using USB 3.0+ speed. Check the Type-A connector and make sure it is blue.

The color code was dropped with USB-C cables. Some of them only have USB-2 wires, which made some devices silently fallback on USB-2 speed.

This patch displays the "negotiated speed" of a device so users can make sure the device is working at the expected speed.

Signed-off-by: Fabien Sanglard <fabien.sanglard@gmail.com>