### PR TITLE
Fix usb-devices to work under busybox

### DIFF
--- a/usb-devices
+++ b/usb-devices
@@ -192,7 +192,7 @@ if [ ! -d /sys/bus ]; then
 	exit 1
 fi
 
-for device in $(find /sys/bus/usb/devices -name 'usb*' -printf '%f\n' | sort -V)
+for device in $(find /sys/bus/usb/devices -name 'usb*' | sed -E 's#^.*/##g' | sort -V)
 do
 	print_device "/sys/bus/usb/devices/$device" 0 0 0
 done


### PR DESCRIPTION
The previous implementation relied on the -printf option for find, which is not implemented in BusyBox.

Replaced it with sed to find the basenae of files reliably.