### PR TITLE
usbutils.pc.in: Fix Cflags entry

### DIFF
--- a/usbutils.pc.in
+++ b/usbutils.pc.in
@@ -15,4 +15,4 @@ Requires: libusb-1.0 >= 1.0.14  libudev >= 196
 Conflicts:
 Libs: -L${libdir}
 Libs.private: @LIBUSB_LIBS@ @UDEV_LIBS@
-Cflags: @CFLAGS@ @LIBUSB_CFLAGS@ @UDEV_CFLAGS@
+Cflags: -I${includedir}


### PR DESCRIPTION
When updating the usbutils version in OpenEmbedded from 015 to 017, the following QA error is seen:

QA Issue: File /usr/lib/pkgconfig/usbutils.pc in package usbutils-dev contains reference to TMPDIR [buildpaths]

As this causes reproducibility problem due to the host PC path being leaked, it is treated as error.

Fix it by using the standard Cflags entry.