### PR TITLE
Add lsusb.py.1 to DISTCLEANFILES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,7 @@ usb-devices.1: $(srcdir)/usb-devices.1.in
 
 DISTCLEANFILES = \
 	lsusb.py \
+	lsusb.py.1 \
 	lsusb.8 \
 	usb-devices.1 \
 	usbhid-dump.8


### PR DESCRIPTION
Commit 83690ec408b2 ("Add a manpage for lsusb.py") added the lsusb.py.1 manpage but forgot to add it to DISTCLEANFILES. Fix that.