### PR TITLE
v2 usbutils.pc.in: Fix Cflags entry

### DIFF
--- a/usbutils.pc.in
+++ b/usbutils.pc.in
@@ -15,4 +15,4 @@ Requires: libusb-1.0 >= 1.0.14  libudev >= 196
 Conflicts:
 Libs: -L${libdir}
 Libs.private: @LIBUSB_LIBS@ @UDEV_LIBS@
-Cflags: @CFLAGS@ @LIBUSB_CFLAGS@ @UDEV_CFLAGS@
+Cflags: -I${includedir}


### PR DESCRIPTION
When updating the usbutils version in OpenEmbedded from 015 to 017, the following QA error is seen:

QA Issue: File /usr/lib/pkgconfig/usbutils.pc in package usbutils-dev contains reference to TMPDIR [buildpaths]

As this causes reproducibility problem due to the host PC path being leaked, it is treated as error.

The generated Cflags section of the resultant usbutils.pc binary that goes into the rootfs looks like this:

Cflags:  -O2 -pipe -g -feliminate-unused-debug-types -fcanon-prefix-map  -fmacro-prefix-map=/work/festevam/oe/poky/build/tmp/work/core2-64-poky-linux/usbutils/017/git=/usr/src/debug/usbutils/017  -fdebug-prefix-map=/work/festevam/oe/poky/build/tmp/work/core2-64-poky-linux/usbutils/017/git=/usr/src/debug/usbutils/017  -fmacro-prefix-map=/work/festevam/oe/poky/build/tmp/work/core2-64-poky-linux/usbutils/017/build=/usr/src/debug/usbutils/017  -fdebug-prefix-map=/work/festevam/oe/poky/build/tmp/work/core2-64-poky-linux/usbutils/017/build=/usr/src/debug/usbutils/017  -fdebug-prefix-map=/work/festevam/oe/poky/build/tmp/work/core2-64-poky-linux/usbutils/017/recipe-sysroot=  -fmacro-prefix-map=/work/festevam/oe/poky/build/tmp/work/core2-64-poky-linux/usbutils/017/recipe-sysroot=  -fdebug-prefix-map=/work/festevam/oe/poky/build/tmp/work/core2-64-poky-linux/usbutils/017/recipe-sysroot-native=  -I/work/festevam/oe/poky/build/tmp/work/core2-64-poky-linux/usbutils/017/recipe-sysroot/usr/include/libusb-1.0

This is not good, as it leaks the host PC paths and breaks reproducibility.

According to https://people.freedesktop.org/~dbn/pkg-config-guide.html:

"Cflags: The compiler flags specific to this package and any required libraries that don't support pkg-config.
If the required libraries support pkg-config, they should be added to Requires or Requires.private."

Both libusb and udev support pkg-config and they are already present in the Requires entry.

Fix the problem by using the standard Cflags entry.