### PR TITLE
Do not warn about missing LPM bit when not required

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -3123,7 +3123,7 @@ dump_device_status(libusb_device_handle *fd, int otg, int super_speed)
 		printf("  Debug Mode\n");
 }
 
-static void dump_usb2_device_capability_desc(unsigned char *buf)
+static void dump_usb2_device_capability_desc(unsigned char *buf, bool lpm_required)
 {
 	unsigned int wide;
 
@@ -3135,8 +3135,10 @@ static void dump_usb2_device_capability_desc(unsigned char *buf)
 			"    bDevCapabilityType  %5u\n"
 			"    bmAttributes   0x%08x\n",
 			buf[0], buf[1], buf[2], wide);
-	if (!(wide & 0x02))
+	if ((lpm_required || (wide & 0x04)) && !(wide & 0x02))
 		printf("      (Missing must-be-set LPM bit!)\n");
+	else if (!lpm_required && !(wide & 0x02))
+		printf("      Link Power Management (LPM) not supported\n");
 	else if (!(wide & 0x04))
 		printf("      HIRD Link Power Management (LPM)"
 				" Supported\n");
@@ -3434,7 +3436,7 @@ static void dump_billboard_alt_mode_capability_desc(unsigned char *buf)
 			buf[4], buf[5], buf[6], buf[7]);
 }
 
-static void dump_bos_descriptor(libusb_device_handle *fd, bool* has_ssp)
+static void dump_bos_descriptor(libusb_device_handle *fd, bool* has_ssp, bool lpm_required)
 {
 	/* Total length of BOS descriptors varies.
 	 * Read first static 5 bytes which include the total length before
@@ -3501,7 +3503,7 @@ static void dump_bos_descriptor(libusb_device_handle *fd, bool* has_ssp)
 			/* FIXME */
 			break;
 		case USB_DC_20_EXTENSION:
-			dump_usb2_device_capability_desc(buf);
+			dump_usb2_device_capability_desc(buf, lpm_required);
 			break;
 		case USB_DC_SUPERSPEED:
 			dump_ss_device_capability_desc(buf);
@@ -3585,7 +3587,7 @@ static void dumpdev(libusb_device *dev)
 		return;
 
 	if (desc.bcdUSB >= 0x0201)
-		dump_bos_descriptor(udev, &has_ssp);
+		dump_bos_descriptor(udev, &has_ssp, desc.bcdUSB >= 0x0210);
 	if (desc.bDeviceClass == LIBUSB_CLASS_HUB)
 		do_hub(udev, desc.bDeviceProtocol, desc.bcdUSB, has_ssp);
 	if (desc.bcdUSB == 0x0200) {


### PR DESCRIPTION
The bcdUSB value 0x0210 defined in USB 3.2 Specification indicates USB 3.2 device operating in one of the USB 2.0 modes. USB 2.0 Link Power Management Addendum defines bcdUSB value 0x0201 to indicate that USB 2.0 device supports the request to read the BOS Descriptor.

The main difference between bcdUSB 0x0210 and 0x0201 is that the USB 3.2 device must support LPM, while USB 2.0 devices can (but are not required to) support LPM.

The difference is respected by USB 3 Gen X Command Verifier (2.3.0.0) Chapter 9 Tests [USB 2 devices], where the test behaves as follows:

      * For bcdUSB 0x0200:
          Checking Device Under Test for LPM L1 Compatibility...
          USB version of device is 2.00.
          DUT is NOT compatible with LPM.
          LPM is NOT required for DUT
          LPM is only supported in USB version 2.01 and above.
    
      * For bcdUSB 0x0201:
          Checking Device Under Test for LPM L1 Compatibility...
          USB version of device is 2.01.
          DUT IS compatible with LPM.
          LPM is NOT required for DUT
          USB 2.0 Extension Descriptor bmAttributes:
            LPM Capable = 0
            BESL and Alternate HIRD Supported = 0
            Baseline BESL Valid = 0
            Deep BESL Valid = 0
            Baseline BESL: 0d
            Deep BESL:  0d
          LPM is not supported
    
      * For bcdUSB 0x0210:
          Checking Device Under Test for LPM L1 Compatibility...
          USB version of device is 2.10.
          DUT IS compatible with LPM.
          LPM IS required for DUT
          USB 2.0 Extension Descriptor bmAttributes:
            LPM Capable = 0
            BESL and Alternate HIRD Supported = 0
            Baseline BESL Valid = 0
            Deep BESL Valid = 0
            Baseline BESL: 0d
            Deep BESL:  0d
          (USB: 9.6.2.1.6) Bit 1 in Attributes field of a USB 2.0 Extension
          descriptor returned in response to a GetDescriptor(BOS) request
          must be 1 for LS/FS/HS devices that support LPM L1.


The LPM bit must be set only when bcdUSB is at least 0x0210 or when BESL bit is set. Change the check to only print missing must-be-set LPM bit warning when it is required by the specification.