### PR TITLE
usbmisc: fix possible stack-buffer-overflow

### DIFF
--- a/usbmisc.c
+++ b/usbmisc.c
@@ -53,6 +53,7 @@ static int readlink_recursive(const char *path, char *buf, size_t bufsize)
 		return readlink_recursive(temp, buf, bufsize);
 	} else {
 		strncpy(buf, path, bufsize);
+		buf[bufsize - 1] = 0;
 		return strlen(buf);
 	}
 }


### PR DESCRIPTION
Running lsusb with -D argument and path, which len is more than PATH_MAX + 1, cause stack-buffer-overflow because of copy to the buf a string without null-terminator Force setting 0 byte to the end of the buf fixes this error.