### PR TITLE
usb-devices: Fix usb-devices with busybox

### DIFF
--- a/usb-devices
+++ b/usb-devices
@@ -192,7 +192,7 @@ if [ ! -d /sys/bus ]; then
 	exit 1
 fi
 
-for device in $(find /sys/bus/usb/devices -name 'usb*' -printf '%f\n' | sort -V)
+for device in $(find /sys/bus/usb/devices -name 'usb*' | sed -E 's#^.*/##g' | sort -V)
 do
 	print_device "/sys/bus/usb/devices/$device" 0 0 0
 done


### PR DESCRIPTION
I recently stumbled over the busybox issue for usb-devices likewise to https://github.com/gregkh/usbutils/pull/181
So here is a new attempted to fix it using the same solution. 

The busybox find command is missing the -printf parameter leading to the error:

find: unrecognized: -printf

Replace the parameter with sed.

This patch was originally created by Daniel Fancsali.