### PR TITLE
Resolve "foo discards const qualifier" warnings et al.

### DIFF
--- a/desc-defs.c
+++ b/desc-defs.c
@@ -541,7 +541,7 @@ static const struct desc desc_audio_3_ac_proc_unit_stereo_extender[] = {
 };
 
 /** UAC3: 4.5.2.10.3 Multi Func Proc Unit Descriptor; Algorithms; Table 4-41. */
-static const char *uac3_proc_unit_multi_func_algorithms[] = {
+static const char * const uac3_proc_unit_multi_func_algorithms[] = {
 	[0] = "Algorithm Undefined.",
 	[1] = "Beam Forming.",
 	[2] = "Acoustic Echo Cancellation.",

--- a/lsusb.c
+++ b/lsusb.c
@@ -151,7 +151,7 @@ static void dump_midistreaming_interface(libusb_device_handle *dev, const unsign
 static void dump_videocontrol_interface(libusb_device_handle *dev, const unsigned char *buf, int protocol);
 static void dump_videostreaming_interface(const unsigned char *buf);
 static void dump_dfu_interface(const unsigned char *buf);
-static char *dump_comm_descriptor(libusb_device_handle *dev, const unsigned char *buf, char *indent);
+static void dump_comm_descriptor(libusb_device_handle *dev, const unsigned char *buf, const char *indent);
 static void dump_hid_device(libusb_device_handle *dev, const struct libusb_interface_descriptor *interface, const unsigned char *buf);
 static void dump_printer_device(libusb_device_handle *dev, const struct libusb_interface_descriptor *interface, const unsigned char *buf);
 static void dump_audiostreaming_endpoint(libusb_device_handle *dev, const unsigned char *buf, int protocol);
@@ -2538,8 +2538,8 @@ static void dump_hid_device(libusb_device_handle *dev,
 	}
 }
 
-static char *
-dump_comm_descriptor(libusb_device_handle *dev, const unsigned char *buf, char *indent)
+static void
+dump_comm_descriptor(libusb_device_handle *dev, const unsigned char *buf, const char *indent)
 {
 	int		tmp;
 	char		*str = NULL;
@@ -2818,17 +2818,16 @@ dump_comm_descriptor(libusb_device_handle *dev, const unsigned char *buf, char *
 		/* FIXME there are about a dozen more descriptor types */
 		printf("%sUNRECOGNIZED CDC: ", indent);
 		dump_bytes(buf, buf[0]);
-		return "unrecognized comm descriptor";
+		return;
 	}
 
 	free(str);
 
-	return 0;
+	return;
 
 bad:
 	printf("%sINVALID CDC (%s): ", indent, type);
 	dump_bytes(buf, buf[0]);
-	return "corrupt comm descriptor";
 }
 
 /* ---------------------------------------------------------------------- */

--- a/lsusb.c
+++ b/lsusb.c
@@ -684,7 +684,7 @@ static void dump_interface(libusb_device_handle *dev, const struct libusb_interf
 
 static void dump_pipe_desc(const unsigned char *buf)
 {
-	static const char *pipe_name[] = {
+	static const char * const pipe_name[] = {
 		"Reserved",
 		"Command pipe",
 		"Status pipe",
@@ -830,10 +830,15 @@ static void dump_endpoint(libusb_device_handle *dev, const struct libusb_interfa
 
 static void dump_unit(unsigned int data, unsigned int len)
 {
-	char *systems[5] = { "None", "SI Linear", "SI Rotation",
-			"English Linear", "English Rotation" };
+	static const char * const systems[5] = {
+		"None",
+		"SI Linear",
+		"SI Rotation",
+		"English Linear",
+		"English Rotation",
+	};
 
-	char *units[5][8] = {
+	static const char * const units[5][8] = {
 		{ "None", "None", "None", "None", "None",
 				"None", "None", "None" },
 		{ "None", "Centimeter", "Gram", "Seconds", "Kelvin",
@@ -2300,8 +2305,8 @@ static void dump_report_desc(unsigned char *b, int l)
 {
 	unsigned int j, bsize, btag, btype, data = 0xffff, hut = 0xffff;
 	int i;
-	char *types[4] = { "Main", "Global", "Local", "reserved" };
-	char indent[] = "                            ";
+	static const char * const types[4] = { "Main", "Global", "Local", "reserved" };
+	static const char indent[] = "                            ";
 
 	printf("          Report Descriptor: (length is %d)\n", l);
 	for (i = 0; i < l; ) {
@@ -2543,7 +2548,7 @@ dump_comm_descriptor(libusb_device_handle *dev, const unsigned char *buf, const 
 {
 	int		tmp;
 	char		*str = NULL;
-	char		*type;
+	const char	*type;
 
 	switch (buf[2]) {
 	case 0:
@@ -2839,7 +2844,7 @@ static void do_hub(libusb_device_handle *fd, unsigned tt_type, unsigned speed,
 			+ 2 /* bitmasks */ * HUB_STATUS_BYTELEN];
 	int i, ret, value;
 	unsigned int link_state;
-	const char * const link_state_descriptions[] = {
+	static const char * const link_state_descriptions[] = {
 		"U0",
 		"U1",
 		"U2",
@@ -3239,7 +3244,7 @@ static void dump_ssp_device_capability_desc(unsigned char *buf)
 {
 	int i;
 	unsigned int bm_attr, ss_attr;
-	char bitrate_prefix[] = " KMG";
+	static const char bitrate_prefix[] = " KMG";
 
 	if (buf[0] < 12) {
 		fprintf(stderr, "  Bad SuperSpeedPlus USB Device Capability descriptor.\n");
@@ -3293,7 +3298,7 @@ static void dump_container_id_device_capability_desc(unsigned char *buf)
 static char *get_webusb_url(libusb_device_handle *fd, uint8_t vendor_req, uint8_t id)
 {
 	unsigned char url_buf[255];
-	char *scheme;
+	const char *scheme;
 	char *url, *chr;
 	unsigned char i;
 	int ret;

--- a/meson.build
+++ b/meson.build
@@ -60,7 +60,6 @@ add_project_arguments(
     '-Wno-unused-function',
     '-Wno-deprecated-declarations',
     # should be removed and the code fixed
-    '-Wno-discarded-qualifiers',
     '-Wno-incompatible-pointer-types-discards-qualifiers',
     '-Wno-missing-field-initializers',
   ]),

--- a/sysfs.c
+++ b/sysfs.c
@@ -50,7 +50,7 @@ int get_sysfs_name(char *buf, size_t size, libusb_device *dev)
 	return len;
 }
 
-int read_sysfs_prop(char *buf, size_t size, char *sysfs_name, char *propname)
+int read_sysfs_prop(char *buf, size_t size, const char *sysfs_name, const char *propname)
 {
 	int n, fd;
 	char path[PATH_MAX];

--- a/sysfs.h
+++ b/sysfs.h
@@ -10,7 +10,7 @@
 /* ---------------------------------------------------------------------- */
 
 int get_sysfs_name(char *buf, size_t size, libusb_device *dev);
-extern int read_sysfs_prop(char *buf, size_t size, char *sysfs_name, char *propname);
+extern int read_sysfs_prop(char *buf, size_t size, const char *sysfs_name, const char *propname);
 
 /* ---------------------------------------------------------------------- */
 #endif /* _SYSFS_H */


### PR DESCRIPTION
Nothing particularly hard or controversial here ;-)

As the second patch mentions - perhaps we'd want to fixup/rework the hash tables in `usb-spec.h` ... we should be able to move 1/3 of our text to the (ro)data side. Something for a rainy day.