### PR TITLE
ci: run monthly checks by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "ci"
     groups:


### PR DESCRIPTION
Seemingly the CodeQL folks push 1-2 releases a week and the knock on affect is that dependabot will open PRs every week.

Just move to monthly checks/updates.