### PR TITLE
Add the final SPDX identifiers, alongside reuse-lint CI workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+# SPDX-FileCopyrightText: 2024 Lucas De Marchi <lucas.de.marchi@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 name: Build and Test
 
 on:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2024 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+name: Reuse Lint
+
+on:
+  push:
+    branches: [master, ci-test]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "30 2 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  reuse:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup Python
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          _version=$(grep -o "reuse-.*" usbutils.spdx | cut -f2 -d'-')
+          pip install reuse~=$_version
+
+      - name: Check SPDX identifiers
+        run: reuse lint


### PR DESCRIPTION
Add the identifiers and automate the checking process.