### PR TITLE
lsusb: add VideoControl Endpoint Descriptor

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -149,6 +149,7 @@ static void dump_audiocontrol_interface(libusb_device_handle *dev, const unsigne
 static void dump_audiostreaming_interface(libusb_device_handle *dev, const unsigned char *buf, int protocol);
 static void dump_midistreaming_interface(libusb_device_handle *dev, const unsigned char *buf);
 static void dump_videocontrol_interface(libusb_device_handle *dev, const unsigned char *buf, int protocol);
+static void dump_videocontrol_interrupt_endpoint(const unsigned char *buf);
 static void dump_videostreaming_interface(const unsigned char *buf);
 static void dump_dfu_interface(const unsigned char *buf);
 static void dump_comm_descriptor(libusb_device_handle *dev, const unsigned char *buf, const char *indent);
@@ -770,6 +771,10 @@ static void dump_endpoint(libusb_device_handle *dev, const struct libusb_interfa
 					dump_audiostreaming_endpoint(dev, buf, interface->bInterfaceProtocol);
 				else if (interface->bInterfaceClass == 1 && interface->bInterfaceSubClass == 3)
 					dump_midistreaming_endpoint(buf);
+				else if (interface->bInterfaceClass == 14 &&
+					 interface->bInterfaceSubClass == 1)
+					dump_videocontrol_interrupt_endpoint(
+						buf);
 				break;
 			case USB_DT_CS_INTERFACE:
 				/* MISPLACED DESCRIPTOR ... less indent */
@@ -1753,6 +1758,25 @@ static void dump_videocontrol_interface(libusb_device_handle *dev, const unsigne
 	}
 
 	free(term);
+}
+
+static void dump_videocontrol_interrupt_endpoint(const unsigned char *buf)
+{
+	unsigned int wMaxTransferSize;
+
+	if (buf[0] < 5)
+		printf("      Warning: Descriptor too short\n");
+	if (buf[1] != USB_DT_CS_ENDPOINT)
+		printf("      Warning: Invalid descriptor\n");
+	wMaxTransferSize = buf[3] | (buf[4] << 8);
+	printf("        VideoControl Endpoint Descriptor:\n"
+	       "          bLength             %5u\n"
+	       "          bDescriptorType     %5u\n"
+	       "          bDescriptorSubtype  %5u (%s)\n"
+	       "          wMaxTransferSize    %5u\n",
+	       buf[0], buf[1], buf[2], buf[2] == 3 ? "EP_INTERRUPT" : "Invalid",
+	       wMaxTransferSize);
+	dump_junk(buf, "          ", 5);
 }
 
 static void dump_videostreaming_interface(const unsigned char *buf)


### PR DESCRIPTION
Add support for parsing the Class-specific VC Interrupt Endpoint Descriptor as described in UVC 1.1 spec 3.8.2.2.

Sample output, including the preceding endpoint descriptor:
```
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x81  EP 1 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0010  1x 16 bytes
        bInterval               8
        bMaxBurst               0
        VideoControl Endpoint Descriptor:
          bLength                 5
          bDescriptorType        37
          bDescriptorSubtype      3 (EP_INTERRUPT)
          wMaxTransferSize       16
```