### PR TITLE
ci: codeql ignore meson generated files, et al

### DIFF
--- a/.github/actions/setup-debian/action.yml
+++ b/.github/actions/setup-debian/action.yml
@@ -11,6 +11,8 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        export DEBIAN_FRONTEND=noninteractive
+        export TZ=Etc/UTC
         dpkg --add-architecture i386
         apt-get update
         apt-get install --yes \

--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -11,6 +11,8 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        export DEBIAN_FRONTEND=noninteractive
+        export TZ=Etc/UTC
         dpkg --add-architecture i386
         apt-get update
         apt-get install --yes \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,3 +66,19 @@ jobs:
         uses: github/codeql-action/analyze@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
         with:
           category: "/language:cpp"
+          upload: false
+          output: sarif-results
+
+      - name: Filter out meson-internal test files
+        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1.0.1
+        with:
+          patterns: |
+            -build/meson-private/**/testfile.c
+          input: sarif-results/cpp.sarif
+          output: sarif-results/cpp.sarif
+
+      - name: Upload CodeQL results to code scanning
+        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
+        with:
+          sarif_file: sarif-results/cpp.sarif
+          category: "/language:cpp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,9 +59,8 @@ jobs:
 
       - name: Build
         run: |
-          mkdir build && cd build
-          meson setup --native-file ../build-dev.ini . ..
-          meson compile
+          meson setup --native-file build-dev.ini build
+          meson compile -C build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0


### PR DESCRIPTION
Hey Greg, here's a quick PR to silence most of the CodeQL dubious reports. I've also added a couple more CI commits just to keep you on your toes ;-)