### PR TITLE
usbreset: support resetting device by serial number

### DIFF
--- a/man/usbreset.1
+++ b/man/usbreset.1
@@ -22,6 +22,9 @@ Reset by product and vendor IDs
 .BR BBB/DDD
 Reset by bus and device number
 .TP
+.BR "SN:SERIAL"
+Reset by serial number
+.TP
 .BR "Product"
 Reset by product name
 .PP
@@ -41,6 +44,10 @@ Reset device with vendor ID 1234 and product ID 5678:
 .TP
 Reset device 002 on bus 001:
 .B usbreset 001:002
+
+.TP
+Reset device with serial number ABCDEF0
+.B usbreset SN:ABCDEF0
 
 .TP
 Reset device named USB2.0 Hub:

--- a/usbreset.c
+++ b/usbreset.c
@@ -25,6 +25,7 @@ struct usbentry {
 	int product_id;
 	char vendor_name[128];
 	char product_name[128];
+	char serial[128];
 };
 
 static char *sysfs_attr(const char *dev, const char *attr)
@@ -89,6 +90,10 @@ static struct usbentry *parse_devlist(DIR *d)
 	if (attr)
 		strncpy(dev.product_name, attr, sizeof(dev.product_name) - 1);
 
+	attr = sysfs_attr(e->d_name, "serial");
+	if (attr)
+		strncpy(dev.serial, attr, sizeof(dev.serial) - 1);
+
 	if (dev.bus_num && dev.dev_num && dev.vendor_id >= 0 && dev.product_id >= 0)
 		return &dev;
 
@@ -103,14 +108,19 @@ static void list_devices(void)
 	if (!devs)
 		return;
 
-	while ((dev = parse_devlist(devs)) != NULL)
-		printf("  Number %03d/%03d  ID %04x:%04x  %s\n", dev->bus_num, dev->dev_num, dev->vendor_id,
+	while ((dev = parse_devlist(devs)) != NULL) {
+		printf("  Number %03d/%03d  ID %04x:%04x  %s", dev->bus_num, dev->dev_num, dev->vendor_id,
 		       dev->product_id, dev->product_name);
+		if (strlen(dev->serial) > 0) {
+			printf("  SN:%s", dev->serial);
+		}
+		printf("\n");
+	}
 
 	closedir(devs);
 }
 
-static struct usbentry *find_device(int *bus, int *dev, int *vid, int *pid, const char *product)
+static struct usbentry *find_device(int *bus, int *dev, int *vid, int *pid, const char *serial, const char *product)
 {
 	DIR *devs = opendir("/sys/bus/usb/devices");
 
@@ -122,7 +132,7 @@ static struct usbentry *find_device(int *bus, int *dev, int *vid, int *pid, cons
 	while ((e = parse_devlist(devs)) != NULL)
 		if ((bus && (e->bus_num == *bus) && (e->dev_num == *dev)) ||
 		    (vid && (e->vendor_id == *vid) && (e->product_id == *pid)) ||
-		    (product && !strcasecmp(e->product_name, product))) {
+		    (serial && !strcasecmp(e->serial, serial)) || (product && !strcasecmp(e->product_name, product))) {
 			match = e;
 			break;
 		}
@@ -160,15 +170,18 @@ int main(int argc, char **argv)
 	struct usbentry *dev;
 
 	if ((argc == 2) && (sscanf(argv[1], "%3d/%3d", &id1, &id2) == 2))
-		dev = find_device(&id1, &id2, NULL, NULL, NULL);
+		dev = find_device(&id1, &id2, NULL, NULL, NULL, NULL);
 	else if ((argc == 2) && (sscanf(argv[1], "%4x:%4x", &id1, &id2) == 2))
-		dev = find_device(NULL, NULL, &id1, &id2, NULL);
+		dev = find_device(NULL, NULL, &id1, &id2, NULL, NULL);
+	else if ((argc == 2) && (strncmp(argv[1], "SN:", 3) == 0))
+		dev = find_device(NULL, NULL, NULL, NULL, &(argv[1])[3], NULL);
 	else if ((argc == 2) && strlen(argv[1]) < 128)
-		dev = find_device(NULL, NULL, NULL, NULL, argv[1]);
+		dev = find_device(NULL, NULL, NULL, NULL, NULL, argv[1]);
 	else {
 		printf("Usage:\n"
 		       "  usbreset PPPP:VVVV - reset by product and vendor id\n"
 		       "  usbreset BBB/DDD   - reset by bus and device number\n"
+		       "  usbreset SN:SERIAL - reset by serial number\n"
 		       "  usbreset \"Product\" - reset by product name\n\n"
 		       "Devices:\n");
 		list_devices();

--- a/usbreset.c
+++ b/usbreset.c
@@ -104,16 +104,13 @@ static void list_devices(void)
 		return;
 
 	while ((dev = parse_devlist(devs)) != NULL)
-		printf("  Number %03d/%03d  ID %04x:%04x  %s\n",
-			   dev->bus_num, dev->dev_num,
-			   dev->vendor_id, dev->product_id,
-			   dev->product_name);
+		printf("  Number %03d/%03d  ID %04x:%04x  %s\n", dev->bus_num, dev->dev_num, dev->vendor_id,
+		       dev->product_id, dev->product_name);
 
 	closedir(devs);
 }
 
-static struct usbentry *find_device(int *bus, int *dev, int *vid, int *pid,
-				    const char *product)
+static struct usbentry *find_device(int *bus, int *dev, int *vid, int *pid, const char *product)
 {
 	DIR *devs = opendir("/sys/bus/usb/devices");
 
@@ -124,8 +121,8 @@ static struct usbentry *find_device(int *bus, int *dev, int *vid, int *pid,
 
 	while ((e = parse_devlist(devs)) != NULL)
 		if ((bus && (e->bus_num == *bus) && (e->dev_num == *dev)) ||
-			(vid && (e->vendor_id == *vid) && (e->product_id == *pid)) ||
-			(product && !strcasecmp(e->product_name, product))) {
+		    (vid && (e->vendor_id == *vid) && (e->product_id == *pid)) ||
+		    (product && !strcasecmp(e->product_name, product))) {
 			match = e;
 			break;
 		}
@@ -140,13 +137,12 @@ static void reset_device(struct usbentry *dev)
 	int fd;
 	char path[PATH_MAX];
 
-	snprintf(path, sizeof(path) - 1, "/dev/bus/usb/%03d/%03d",
-		dev->bus_num, dev->dev_num);
+	snprintf(path, sizeof(path) - 1, "/dev/bus/usb/%03d/%03d", dev->bus_num, dev->dev_num);
 
 	printf("Resetting %s ... ", dev->product_name);
 
 	fd = open(path, O_WRONLY);
-	if (fd  > -1) {
+	if (fd > -1) {
 		if (ioctl(fd, USBDEVFS_RESET, 0) < 0)
 			printf("failed [%s]\n", strerror(errno));
 		else
@@ -157,7 +153,6 @@ static void reset_device(struct usbentry *dev)
 		printf("can't open [%s]\n", strerror(errno));
 	}
 }
-
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
**usbreset: support resetting device by serial number**

This is especially useful when multiple devices of the same type (where product id, vendor id, and product name are all matching) are connected to the PC and you want to identify the device uniquely with information which is device-inherent (the bus and device number is not because it will change if the device is connect to a different USB port).

Example call `usbreset`

```
Usage:
  usbreset PPPP:VVVV - reset by product and vendor id
  usbreset BBB/DDD   - reset by bus and device number
  usbreset SN:SERIAL - reset by serial number
  usbreset "Product" - reset by product name

Devices:
  Number 001/009  ID 0403:6010 Digilent USB Device SN:25163510001
  Number 001/006  ID 0403:6011 Digilent USB Device SN:25163520001
  Number 001/017  ID 0403:6011 Digilent USB Device SN:25163520002
  Number 001/015  ID 0403:6010 Digilent USB Device SN:25163510002
  Number 001/013  ID 0403:6010 Digilent USB Device SN:25163510003
  Number 001/005  ID 0403:6011 Digilent USB Device SN:25163520003
  Number 001/007  ID 0403:6011 Digilent USB Device SN:25163520004
(...)
```

Example call `usbreset SN:25163510002`

```
Resetting Digilent USB Device ... ok
```