### PR TITLE
usb-devices: add line with busid to device entry

### DIFF
--- a/usb-devices
+++ b/usb-devices
@@ -120,6 +120,8 @@ print_device() {
 
 	[ -d "$devpath" ] || return
 	cd "$devpath" || return
+	printf "\nB:  busid=%s\n" \
+		"$(basename ${devpath})"
 
 	read -r busnum < "busnum"
 	read -r devnum < "devnum"
@@ -132,7 +134,7 @@ print_device() {
 
 	read -r speed < "speed"
 	read -r maxchild < "maxchild"
-	printf "\nT:  Bus=%02i Lev=%02i Prnt=%02i Port=%02i Cnt=%02i Dev#=%3i Spd=%-4s MxCh=%2i\n" \
+	printf "T:  Bus=%02i Lev=%02i Prnt=%02i Port=%02i Cnt=%02i Dev#=%3i Spd=%-4s MxCh=%2i\n" \
 		"$busnum" "$level" "$parent" "$port" "$count" "$devnum" "$speed" "$maxchild"
 
 	read -r ver < "version"


### PR DESCRIPTION
usb-devices is very helpful to locate the USB device you actually want to talk to. But other tools, like usbip, need the USB busid instead.

Update print_devices() to start with a new "B: busid=" line, which shows the basename of the device path.

Example usage:

    # usb-devices 2>/dev/null | grep -B8 -e B002JERC | grep -e busid -e Manufacturer= -e Product=
    B:  busid=1-1.3.2            <-- this is what "usbip" needs
    S:  Manufacturer=FTDI
    S:  Product=FT232R USB UART