### PR TITLE
lsusb-t: add verblevel 3 to print_usbdevice()

### DIFF
--- a/lsusb-t.c
+++ b/lsusb-t.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 /* Copyright (c) 2009 Greg Kroah-Hartman <gregkh@suse.de> */
+#include <stdbool.h>
 #include <stdint.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -200,6 +201,21 @@ static void print_usbdevice(struct usbdevice *d, struct usbinterface *i)
 	if (verblevel >= 2) {
 		printf(" %*s", indent, "    ");
 		printf("%s/%s  /dev/bus/usb/%03d/%03d\n", sys_bus_usb_devices, d->name, d->busnum, d->devnum);
+	}
+	if (verblevel >= 3) {
+		bool hasManufacturer = strlen(d->manufacturer) > 0;
+		bool hasProduct = strlen(d->product) > 0;
+		bool hasSerial = strlen(d->serial) > 0;
+		if (hasManufacturer || hasProduct || hasSerial) {
+			printf(" %*s", indent, "    ");
+			if (hasManufacturer)
+				printf("Manufacturer=%s ", d->manufacturer);
+			if (hasProduct)
+				printf("Product=%s ", d->product);
+			if (hasSerial)
+				printf("Serial=%s", d->serial);
+			printf("\n");
+		}
 	}
 }
 


### PR DESCRIPTION
Print an additional line with iManufacturer, iProduct and iSerial strings when available.

Example output from "lsusb -tvvv":

    |__ Port 001: Dev 005, If 0, Class=Vendor Specific Class, Driver=[none], 12M
        ID 0403:6001 Future Technology Devices International, Ltd FT232 Serial (UART) IC
        /sys/bus/usb/devices/1-1.1  /dev/bus/usb/001/005
        Manufacturer=Prologix Product=Prologix GPIB-USB Controller Serial=PX4IOM5Q