### PR TITLE
usb-devices: Make devcount 'local' to handle recursion

### DIFF
--- a/usb-devices
+++ b/usb-devices
@@ -173,7 +173,7 @@ print_device() {
 		print_interface "$devpath/$interface"
 	done
 
-	devcount=0
+	local devcount=0
 	for subdev in "$busnum"-*
 	do
 		echo "$subdev" | grep -Eq "^$busnum-[0-9]+(\.[0-9]+)*$" \


### PR DESCRIPTION
Commit b1c31712134d2b28877b (usb-devices: use 'local' variable type to handle recursion) made several variables local to print_device() to handle recursion. However, devcount was not defined as a local variable. It is currently treated as a global variable causing it to retain values updated across function calls. As a result, USB devices with the same busnum also have the same 'cnt'.

Define devcount as a local variable so 'cnt' is correctly reported for USB devices sharing the same bus and in the same level.