### PR TITLE
Fix display of HID descriptors

### DIFF
--- a/names.c
+++ b/names.c
@@ -35,11 +35,9 @@ static struct udev_hwdb *hwdb = NULL;
 static const char *names_genericstrtable(const struct genericstrtable *t,
 					 unsigned int idx)
 {
-	const struct genericstrtable *h;
-
-	for (h = t; t->name; t++)
-		if (h->num == idx)
-			return h->name;
+	for (; t->name; t++)
+		if (t->num == idx)
+			return t->name;
 	return NULL;
 }
 


### PR DESCRIPTION
The switch from hash tables to arrays + linear lookups in #202 (cc @evelikov) created a bug -- `names_genericstrtable` uses two variables (`h` and `t`) inconsistently in a loop, causing it to always return `NULL`, except for the first element in the array table.

This in turn causes everything (except "Usage Page") in the HID descriptors to be `(null)` instead of the right string.

I'm a bit surprised that this hasn't been caught by tests...

For comparison here is a snippet from `lsusb -v` without this patch:
```
          Report Descriptor: (length is 103)
            Item(Global): Usage Page, data= [ 0x01 ] 1
                            (null)
            Item(Local ): (null), data= [ 0x06 ] 6
                            (null)
            Item(Main  ): (null), data= [ 0x01 ] 1
                            Application
            Item(Global): (null), data= [ 0x01 ] 1
            Item(Global): Usage Page, data= [ 0x07 ] 7
                            (null)
            Item(Local ): (null), data= [ 0xe0 ] 224
                            (null)
```
And with this patch
```
          Report Descriptor: (length is 103)
            Item(Global): Usage Page, data= [ 0x01 ] 1
                            Generic Desktop Controls
            Item(Local ): Usage, data= [ 0x06 ] 6
                            Keyboard
            Item(Main  ): Collection, data= [ 0x01 ] 1
                            Application
            Item(Global): Report ID, data= [ 0x01 ] 1
            Item(Global): Usage Page, data= [ 0x07 ] 7
                            Keyboard
            Item(Local ): Usage Minimum, data= [ 0xe0 ] 224
                            Control Left
```