### PR TITLE
usbreset.1: fix typo in the busnum/devicenum example

### DIFF
--- a/man/usbreset.1
+++ b/man/usbreset.1
@@ -44,7 +44,7 @@ Reset device with vendor ID 1234 and product ID 5678:
 
 .TP
 Reset device 002 on bus 001:
-.B usbreset 001:002
+.B usbreset 001/002
 
 .TP
 Reset device with serial number ABCDEF0


### PR DESCRIPTION
The manpage description properly shows the slash as separator: BBB/DDD Reset by bus and device number
but the related example wrongly shows a colon as separator.