### PR TITLE
usb-devices: Make devnum 'local' to handle recursion

### DIFF
--- a/usb-devices
+++ b/usb-devices
@@ -117,6 +117,7 @@ print_device() {
 	local parent=$2
 	local level=$3
 	local count=$4
+	local devnum
 
 	[ -d "$devpath" ] || return
 	cd "$devpath" || return


### PR DESCRIPTION
Commit b1c3171 (usb-devices: use 'local' variable type to handle recursion) made several variables local to print_device() to handle recursion. However, devnum was not defined as a local variable. It is currently treated as a global variable causing it to retain values updated across function calls.

Since, a device uses its parent device's devnum to report its prnt, the prnt values of devices which share the same parent are incorrect.

Define devnum as a local variable so 'prnt' is correctly reported for USB devices sharing the same parent.