### PR TITLE
lsusb.py: fix parse_usb_ids

### DIFF
--- a/lsusb.py
+++ b/lsusb.py
@@ -102,7 +102,7 @@ def parse_usb_ids():
 					strg = cstrg + ":" + nm
 				else:
 					strg = cstrg + ":"
-				usbclasses[vid, did, -1] = strg
+				usbclasses[cid, did, -1] = strg
 				continue
 		if ln[0] == 'C':
 			mode = modes.Class


### PR DESCRIPTION
The commit 10144ac broke the usb.ids parser by renaming 'id' to 'vid' instead of 'cid' - fix that.