### PR TITLE
lsusb: fix shift UB and truncated-item reads in HID report dump

### DIFF
--- a/lsusb.c
+++ b/lsusb.c
@@ -2374,6 +2374,9 @@ static void dump_report_desc(unsigned char *b, int l)
 		bsize = b[i] & 0x03;
 		if (bsize == 3)
 			bsize = 4;
+		/* Truncated item: avoid OOB reads of b[i+1+j] */
+		if (bsize > 0 && i + 1 + (int)bsize > l)
+			return;
 		btype = b[i] & (0x03 << 2);
 		btag = b[i] & ~0x03; /* 2 LSB bits encode length */
 		printf("            Item(%-6s): %s, data=", types[btype>>2],
@@ -2383,7 +2386,7 @@ static void dump_report_desc(unsigned char *b, int l)
 			data = 0;
 			for (j = 0; j < bsize; j++) {
 				printf("0x%02x ", b[i+1+j]);
-				data += (b[i+1+j] << (8*j));
+				data += ((unsigned int)b[i+1+j]) << (8U*j);
 			}
 			printf("] %d", data);
 		} else


### PR DESCRIPTION
dump_report_desc() in lsusb assembles an integer value from HID report descriptor bytes. When a byte with bit 7 set is promoted to signed int, left-shifting it can trigger undefined behavior under UBSan.

Also, if the report descriptor contains a truncated item, the code may read past the end of the provided buffer while printing/accumulating the data.

Fix both issues by casting the byte to unsigned int before shifting and by adding a bounds check for truncated items.