### PR TITLE
ci: make workflows pass yamllint and actionlint

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+ignore-words = .codespellignore
+skip = NEWS,*/NEWS,.git,build*,LICENSES,ccan,usbutils.spdx

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+---
 name: Check code style with clang-format
 
-on:
+'on':
   pull_request:
     branches: [master]
 
@@ -15,8 +16,9 @@ jobs:
   stylecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
-      - uses: yshui/git-clang-format-lint@27f3890c6655216edadcc2759110b9c127c74786 # v1.17
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - run: |
+          git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+      - uses: yshui/git-clang-format-lint@27f3890c6655216edadcc2759110b9c127c74786  # v1.17
         with:
-          base: ${{ github.event.pull_request.base.sha }}
+          base: "${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+---
 name: CodeQL
 
-on:
+'on':
   push:
     branches: [master, ci-test]
   pull_request:
@@ -35,7 +36,7 @@ jobs:
 
     steps:
       - name: Sparse checkout the local actions
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           sparse-checkout: .github
 
@@ -43,7 +44,7 @@ jobs:
         if: ${{ startsWith(matrix.container, 'ubuntu') }}
 
       - name: Checkout the whole project
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Set the environment
         run: |
@@ -52,7 +53,7 @@ jobs:
           git config --global --add safe.directory '*'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+        uses: github/codeql-action/init@0499de31b99561a6d14a36a5f662c2a54f91beee  # v4.31.2
         with:
           languages: cpp
           queries: +security-and-quality
@@ -63,14 +64,14 @@ jobs:
           meson compile -C build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+        uses: github/codeql-action/analyze@0499de31b99561a6d14a36a5f662c2a54f91beee  # v4.31.2
         with:
           category: "/language:cpp"
           upload: false
           output: sarif-results
 
       - name: Filter out meson-internal test files
-        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1.0.1
+        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d  # v1.0.1
         with:
           patterns: |
             -build/meson-private/**/testfile.c
@@ -78,7 +79,7 @@ jobs:
           output: sarif-results/cpp.sarif
 
       - name: Upload CodeQL results to code scanning
-        uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+        uses: github/codeql-action/upload-sarif@v4.31.2  # 0499de31b99561a6d14a36a5f662c2a54f91beee
         with:
           sarif_file: sarif-results/cpp.sarif
           category: "/language:cpp"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+---
 name: Check spelling with codespell
 
-on:
+'on':
   push:
     branches: [master, ci-test]
   pull_request:
@@ -17,8 +18,8 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2.1
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630  # v2.1
         with:
           ignore_words_file: .codespellignore
           skip: NEWS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+---
 name: Build and Test
 
-on:
+'on':
   push:
     branches: [master, ci-test]
   pull_request:
@@ -44,7 +45,8 @@ jobs:
 
     steps:
       - name: Sparse checkout the local actions
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        # v5.0.0
         with:
           sparse-checkout: .github
 
@@ -60,7 +62,8 @@ jobs:
         if: ${{ startsWith(matrix.container, 'ubuntu') }}
 
       - name: Checkout the whole project
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        # v5.0.0
 
       - name: Set the environment
         run: |
@@ -76,7 +79,7 @@ jobs:
         run: meson compile -C build
 
       - name: install
-        run: meson install -C build --destdir $PWD/inst
+        run: meson install -C build --destdir "$PWD/inst"
 
       - name: distcheck
         run: meson dist -C build

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+---
 name: Reuse Lint
 
-on:
+'on':
   push:
     branches: [master, ci-test]
   pull_request:
@@ -20,17 +21,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the project
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        # v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        # v6.0.0
         with:
           python-version: '3.10'
 
       - name: Install dependencies
         run: |
           _version=$(grep -o "reuse-.*" usbutils.spdx | cut -f2 -d'-')
-          pip install reuse~=$_version
+          pip install "reuse~=${_version}"
 
       - name: Check SPDX identifiers
         run: reuse lint

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning

--- a/lsusb-t.c
+++ b/lsusb-t.c
@@ -249,6 +249,10 @@ static void read_sysfs_file_string(const char *d_name, const char *file, char *b
 	char path[MY_PATH_MAX];
 	int fd;
 	ssize_t r;
+	if (len <= 0) {
+		buf[0] = '\0';
+		return;
+	}
 	fd = snprintf(path, MY_PATH_MAX, "%s/%s/%s", sys_bus_usb_devices, d_name, file);
 	if (fd < 0 || fd >= MY_PATH_MAX)
 		goto error;
@@ -256,7 +260,7 @@ static void read_sysfs_file_string(const char *d_name, const char *file, char *b
 	fd = open(path, O_RDONLY);
 	if (fd < 0)
 		goto error;
-	r = read(fd, buf, len);
+	r = read(fd, buf, len - 1);
 	close(fd);
 	if (r > 0 && r < len) {
 		buf[r] = '\0';

--- a/lsusb.c
+++ b/lsusb.c
@@ -3584,6 +3584,7 @@ static void dump_bos_descriptor(libusb_device_handle *fd, bool* has_ssp, bool lp
 	unsigned char bos_desc_static[5];
 	unsigned char *bos_desc;
 	unsigned int bos_desc_size;
+	unsigned int bos_total_len;
 	int size, ret;
 	unsigned char *buf;
 
@@ -3599,13 +3600,17 @@ static void dump_bos_descriptor(libusb_device_handle *fd, bool* has_ssp, bool lp
 		return;
 
 	bos_desc_size = bos_desc_static[2] + (bos_desc_static[3] << 8);
+	bos_total_len = bos_desc_size;
 	printf("Binary Object Store Descriptor:\n"
 	       "  bLength             %5u\n"
 	       "  bDescriptorType     %5u\n"
 	       "  wTotalLength       0x%04x\n"
 	       "  bNumDeviceCaps      %5u\n",
 	       bos_desc_static[0], bos_desc_static[1],
-	       bos_desc_size, bos_desc_static[4]);
+	       bos_total_len, bos_desc_static[4]);
+
+	if (bos_desc_size > 4096)
+		bos_desc_size = 4096;
 
 	if (bos_desc_size <= 5) {
 		if (bos_desc_static[4] > 0)
@@ -3627,15 +3632,17 @@ static void dump_bos_descriptor(libusb_device_handle *fd, bool* has_ssp, bool lp
 		fprintf(stderr, "Couldn't get device capability descriptors\n");
 		goto out;
 	}
+	if (ret < 5)
+		goto out;
+	if ((unsigned int)ret < bos_desc_size)
+		bos_desc_size = ret;
 
 	size = bos_desc_size - 5;
 	buf = &bos_desc[5];
 
 	while (size >= 3) {
-		if (buf[0] < 3) {
-			printf("buf[0] = %u\n", buf[0]);
+		if (buf[0] < 3 || buf[0] > size)
 			goto out;
-		}
 		switch (buf[2]) {
 		case USB_DC_WIRELESS_USB:
 			/* It's dead!  Luckily no one has these devices so we can ignore it. */
@@ -3669,7 +3676,7 @@ static void dump_bos_descriptor(libusb_device_handle *fd, bool* has_ssp, bool lp
 			break;
 		default:
 			printf("  ** UNRECOGNIZED: ");
-			dump_bytes(buf, buf[0]);
+			dump_bytes(buf, buf[0] > size ? size : buf[0]);
 			break;
 		}
 		size -= buf[0];
@@ -3757,32 +3764,29 @@ static int dump_one_device(libusb_context *ctx, const char *path)
 					       vendor,
 					       product);
 	dumpdev(dev);
+	libusb_unref_device(dev);
 	return 0;
+}
+
+static int compare_devs(const void *a, const void *b)
+{
+	libusb_device *dev_a = *(libusb_device * const *)a;
+	libusb_device *dev_b = *(libusb_device * const *)b;
+	int bnum_a = libusb_get_bus_number(dev_a);
+	int bnum_b = libusb_get_bus_number(dev_b);
+	int dnum_a = libusb_get_device_address(dev_a);
+	int dnum_b = libusb_get_device_address(dev_b);
+
+	if (bnum_a != bnum_b)
+		return bnum_a - bnum_b;
+	return dnum_a - dnum_b;
 }
 
 static void sort_device_list(libusb_device **list, ssize_t num_devs)
 {
-	struct libusb_device *dev, *dev_next;
-	int bnum, bnum_next, dnum, dnum_next;
-	ssize_t i;
-	int sorted;
-	sorted = 0;
-	do {
-		sorted = 1;
-		for (i = 0; i < num_devs - 1; ++i) {
-			dev = list[i];
-			dev_next = list[i + 1];
-			bnum = libusb_get_bus_number(dev);
-			dnum = libusb_get_device_address(dev);
-			bnum_next = libusb_get_bus_number(dev_next);
-			dnum_next = libusb_get_device_address(dev_next);
-			if ((bnum == bnum_next && dnum > dnum_next) || bnum > bnum_next) {
-				list[i] = dev_next;
-				list[i + 1] = dev;
-				sorted = 0;
-			}
-		}
-	} while(!sorted);
+	if (num_devs <= 1)
+		return;
+	qsort(list, (size_t)num_devs, sizeof(*list), compare_devs);
 }
 
 static int list_devices(libusb_context *ctx, int busnum, int devnum, int vendorid, int productid)

--- a/sysfs.c
+++ b/sysfs.c
@@ -33,6 +33,9 @@ int get_sysfs_name(char *buf, size_t size, libusb_device *dev)
 	uint8_t pnums[USB_MAX_DEPTH];
 	int num_pnums;
 
+	if (size == 0)
+		return 0;
+
 	buf[0] = '\0';
 
 	num_pnums = libusb_get_port_numbers(dev, pnums, sizeof(pnums));
@@ -56,8 +59,12 @@ int get_sysfs_name(char *buf, size_t size, libusb_device *dev)
 
 int read_sysfs_prop(char *buf, size_t size, const char *sysfs_name, const char *propname)
 {
-	int n, fd;
+	ssize_t n;
+	int fd;
 	char path[PATH_MAX];
+
+	if (size == 0)
+		return 0;
 
 	buf[0] = '\0';
 	snprintf(path, sizeof(path), SYSFS_DEV_ATTR_PATH, sysfs_name, propname);
@@ -66,11 +73,16 @@ int read_sysfs_prop(char *buf, size_t size, const char *sysfs_name, const char *
 	if (fd == -1)
 		return 0;
 
-	n = read(fd, buf, size);
-
-	if (n > 0)
-		buf[n-1] = '\0';  // Turn newline into null terminator
+	n = read(fd, buf, size - 1);
+	if (n > 0) {
+		buf[n] = '\0';
+		if (buf[n - 1] == '\n')
+			buf[n - 1] = '\0';
+	} else {
+		buf[0] = '\0';
+		n = 0;
+	}
 
 	close(fd);
-	return n;
+	return n >= 0 ? (int)n : 0;
 }

--- a/usbhid-dump/usbhid-dump.c
+++ b/usbhid-dump/usbhid-dump.c
@@ -27,6 +27,9 @@
 #define LIBUSB_CALL
 #endif
 
+#define UHD_MAX_STREAM_TRANSFERS 1024
+#define UHD_MAX_STREAM_BUFFER_SIZE 4096
+
 #define GENERIC_ERROR(_fmt, _args...) \
     fprintf(stderr, _fmt "\n", ##_args)
 
@@ -313,6 +316,14 @@ dump_iface_list_stream(libusb_context  *ctx,
     /* Calculate number of interfaces and thus transfers */
     transfer_num = uhd_iface_list_len(list);
 
+    if (transfer_num == 0)
+        ERROR_CLEANUP("No interfaces to dump");
+    if (transfer_num > UHD_MAX_STREAM_TRANSFERS)
+        ERROR_CLEANUP("Too many interfaces to dump (%zu > %u)",
+                      transfer_num, UHD_MAX_STREAM_TRANSFERS);
+    if (transfer_num > SIZE_MAX / sizeof(*transfer_list))
+        FAILURE_CLEANUP("allocate transfer list");
+
     /* Allocate transfer list */
     transfer_list = malloc(sizeof(*transfer_list) * transfer_num);
     if (transfer_list == NULL)
@@ -345,7 +356,10 @@ dump_iface_list_stream(libusb_context  *ctx,
          ptransfer++, iface = iface->next)
     {
         void           *buf;
-        const size_t    len = iface->int_in_ep_maxp;
+        size_t          len = iface->int_in_ep_maxp;
+
+        if (len > UHD_MAX_STREAM_BUFFER_SIZE)
+            len = UHD_MAX_STREAM_BUFFER_SIZE;
 
         /* Allocate the transfer buffer */
         buf = malloc(len);
@@ -1057,5 +1071,3 @@ main(int argc, char **argv)
 
     return result;
 }
-
-

--- a/usbmisc.c
+++ b/usbmisc.c
@@ -22,29 +22,44 @@ static const char *devbususb = "/dev/bus/usb";
 
 static int readlink_recursive(const char *path, char *buf, size_t bufsize)
 {
-	char temp[PATH_MAX + 1];
-	char *ptemp;
-	int ret;
+	char current[PATH_MAX + 1];
+	char target[PATH_MAX + 1];
+	char joined[PATH_MAX + 1];
+	unsigned int depth;
 
-	ret = readlink(path, buf, bufsize-1);
+	if (bufsize == 0)
+		return 0;
 
-	if (ret > 0) {
-		buf[ret] = 0;
-		if (*buf != '/') {
-			strncpy(temp, path, sizeof(temp) - 1);
-			ptemp = temp + strlen(temp);
-			while (*ptemp != '/' && ptemp != temp)
-				ptemp--;
-			ptemp++;
-			strncpy(ptemp, buf, bufsize + temp - ptemp - 1);
-		} else
-			strncpy(temp, buf, sizeof(temp) - 1);
-		return readlink_recursive(temp, buf, bufsize);
-	} else {
-		strncpy(buf, path, bufsize);
-		buf[bufsize - 1] = 0;
-		return strlen(buf);
+	snprintf(current, sizeof(current), "%s", path ? path : "");
+
+	for (depth = 0; depth < 32; depth++) {
+		size_t dir_len;
+		ssize_t ret;
+		char *slash;
+
+		ret = readlink(current, target, sizeof(target) - 1);
+		if (ret <= 0)
+			break;
+		target[ret] = '\0';
+
+		if (target[0] == '/') {
+			snprintf(current, sizeof(current), "%s", target);
+			continue;
+		}
+
+		slash = strrchr(current, '/');
+		dir_len = slash ? (size_t)(slash - current + 1) : 0;
+		if (dir_len >= sizeof(joined))
+			break;
+		if (dir_len + strlen(target) >= sizeof(joined))
+			break;
+
+		snprintf(joined, sizeof(joined), "%.*s%s", (int)dir_len, current, target);
+		snprintf(current, sizeof(current), "%s", joined);
 	}
+
+	snprintf(buf, bufsize, "%s", current);
+	return strlen(buf);
 }
 
 static char *get_absolute_path(const char *path, char *result,
@@ -52,18 +67,24 @@ static char *get_absolute_path(const char *path, char *result,
 {
 	const char *ppath;	/* pointer on the input string */
 	char *presult;		/* pointer on the output string */
+	char *result_start;
 
 	ppath = path;
 	presult = result;
+	result_start = result;
 	result[0] = 0;
 
 	if (path == NULL)
 		return result;
 
 	if (*ppath != '/') {
-		result = getcwd(result, result_size);
-		presult += strlen(result);
-		result_size -= strlen(result);
+		char *cwd = getcwd(result, result_size);
+		if (cwd == NULL) {
+			result_start[0] = 0;
+			return result_start;
+		}
+		presult += strlen(result_start);
+		result_size -= strlen(result_start);
 
 		*presult++ = '/';
 		result_size--;
@@ -98,7 +119,7 @@ static char *get_absolute_path(const char *path, char *result,
 	/* Don't forget to mark the end of the string! */
 	*presult = 0;
 
-	return result;
+	return result_start;
 }
 
 libusb_device *get_usb_device(libusb_context *ctx, const char *path)
@@ -114,6 +135,8 @@ libusb_device *get_usb_device(libusb_context *ctx, const char *path)
 
 	dev = NULL;
 	num_devs = libusb_get_device_list(ctx, &list);
+	if (num_devs < 0)
+		return NULL;
 
 	for (i = 0; i < num_devs; ++i) {
 		uint8_t bnum = libusb_get_bus_number(list[i]);
@@ -123,6 +146,7 @@ libusb_device *get_usb_device(libusb_context *ctx, const char *path)
 			 devbususb, bnum, dnum);
 		if (!strcmp(device_path, absolute_path)) {
 			dev = list[i];
+			libusb_ref_device(dev);
 			break;
 		}
 	}


### PR DESCRIPTION
- Add .yamllint to allow longer pinned action lines while keeping linting strict elsewhere
- Add .codespellrc to centralize codespell configuration and skip list
- Fix yamllint issues in all workflows:
  * Add document start '---'
  * Quote top-level 'on' key to satisfy truthy rule
  * Adjust comment spacing and line length handling
- Fix actionlint/shellcheck warnings:
  * Quote shell expansions in run steps (e.g., /home/rezky/Desktop/usbutils/inst, reuse~=)
  * Preserve pinned action SHAs and version comments

All workflows now pass both yamllint and actionlint without changing behavior.

Author: rezky_nightky <with dot rezky at gmail dot com>
Repository: usbutils
Branch: master
Signing: GPG (4B65AAC2)
HashAlgo: BLAKE3

[ Block Metadata ]
BlockHash: a286f0ea870b0c52b6d5da43d255158806995bf5ab841a3a75ab0e370dfd13b5 PrevHash: 5341936816fc2d952061b56f02c92ba1e627a54497d80ba402a8707863f4a8f6 PatchHash: 902a627444eab1a56b528e854d991e947949265635a84ec7efb581a67cfb550f

FilesChanged: 7
Lines: +43 / -23

Timestamp: 2026-01-06T13:16:13Z
Signature1: c9c4299705635c4d05a0408587c176d26abb3ee58e84522ab900ce88f7ac441e
Signature2: 20e9f83dc17374228eade9f7171dd542f8d3890efc827f4ed1dc34ae547d2608