### PR TITLE
usbreset: return failure when device reset fails

### DIFF
--- a/usbreset.c
+++ b/usbreset.c
@@ -167,9 +167,10 @@ static struct usbentry *find_device(int *bus, int *dev, int *vid, int *pid, cons
 	return found ? &match : NULL;
 }
 
-static void reset_device(struct usbentry *dev)
+static int reset_device(struct usbentry *dev)
 {
 	int fd;
+	int ret = EXIT_FAILURE;
 	char path[PATH_MAX];
 
 	snprintf(path, sizeof(path) - 1, "/dev/bus/usb/%03d/%03d", dev->bus_num, dev->dev_num);
@@ -180,13 +181,17 @@ static void reset_device(struct usbentry *dev)
 	if (fd > -1) {
 		if (ioctl(fd, USBDEVFS_RESET, 0) < 0)
 			printf("failed [%s]\n", strerror(errno));
-		else
+		else {
 			printf("ok\n");
+			ret = EXIT_SUCCESS;
+		}
 
 		close(fd);
 	} else {
 		printf("can't open [%s]\n", strerror(errno));
 	}
+
+	return ret;
 }
 
 int main(int argc, char **argv)
@@ -218,6 +223,5 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	reset_device(dev);
-	return 0;
+	return reset_device(dev);
 }


### PR DESCRIPTION
Fixes #256: usbreset currently prints an error but returns success when either open() or USBDEVFS_RESET fails. 

This PR makes reset_device() return failure for both error paths and return success only after USBDEVFS_RESET completes successfully.

### Testing
- Compiled usbreset.c with GCC using warnings as errors.
- Injected an EACCES failure into open(); the exit status was 1.
- Injected an EIO failure into USBDEVFS_RESET; the exit status was 1.
- Successfully reset my attached Epson Perfection V39; the exit status was 0

Looking through the history, it appears the original usbreset behavior returned a nonzero status when open() or the reset ioctl failed but that behavior may have been accidentally removed in the OpenWrt usability refactor in commit 'a02f015'.